### PR TITLE
refactor: use MaybeSend/MaybeSync on registry traits

### DIFF
--- a/crates/core/src/maybe_send.rs
+++ b/crates/core/src/maybe_send.rs
@@ -4,11 +4,13 @@
 //! On native targets, `MaybeSend` resolves to `Send` and `MaybeSync` to
 //! `Sync`. On `wasm32` targets, both are no-ops.
 //!
-//! Only used for traits that genuinely need it: [`ProxyBackend`](crate::backend::ProxyBackend),
+//! Used by traits whose implementations may hold `!Send` types on WASM:
+//! [`ProxyBackend`](crate::backend::ProxyBackend),
 //! [`Middleware`](crate::middleware::Middleware),
-//! [`RouteHandler`](crate::route_handler::RouteHandler), and the
+//! [`RouteHandler`](crate::route_handler::RouteHandler),
+//! [`BucketRegistry`](crate::registry::BucketRegistry),
+//! [`CredentialRegistry`](crate::registry::CredentialRegistry), and the
 //! `oidc-provider` crate's [`HttpExchange`] / [`CredentialExchange`] traits.
-//! Other traits use plain `Send + Sync`.
 
 // --- Native targets: MaybeSend = Send, MaybeSync = Sync ---
 

--- a/crates/core/src/registry/bucket.rs
+++ b/crates/core/src/registry/bucket.rs
@@ -3,6 +3,7 @@
 use crate::api::list_rewrite::ListRewrite;
 use crate::api::response::BucketEntry;
 use crate::error::ProxyError;
+use crate::maybe_send::{MaybeSend, MaybeSync};
 use crate::types::{BucketConfig, BucketOwner, ResolvedIdentity, S3Operation};
 use std::future::Future;
 
@@ -32,7 +33,7 @@ pub struct ResolvedBucket {
 /// parsing the S3 request and resolving the caller's identity.
 ///
 /// Implementations should be cheap to clone (wrap inner state in `Arc`).
-pub trait BucketRegistry: Clone + Send + Sync + 'static {
+pub trait BucketRegistry: Clone + MaybeSend + MaybeSync + 'static {
     /// Resolve a bucket by name, checking authorization for the given identity and operation.
     ///
     /// Returns `Err(ProxyError::BucketNotFound)` if the bucket doesn't exist,
@@ -42,13 +43,13 @@ pub trait BucketRegistry: Clone + Send + Sync + 'static {
         name: &str,
         identity: &ResolvedIdentity,
         operation: &S3Operation,
-    ) -> impl Future<Output = Result<ResolvedBucket, ProxyError>> + Send;
+    ) -> impl Future<Output = Result<ResolvedBucket, ProxyError>> + MaybeSend;
 
     /// List all buckets visible to the given identity.
     fn list_buckets(
         &self,
         identity: &ResolvedIdentity,
-    ) -> impl Future<Output = Result<Vec<BucketEntry>, ProxyError>> + Send;
+    ) -> impl Future<Output = Result<Vec<BucketEntry>, ProxyError>> + MaybeSend;
 
     /// The owner identity returned in `ListAllMyBucketsResult` responses.
     ///

--- a/crates/core/src/registry/credential.rs
+++ b/crates/core/src/registry/credential.rs
@@ -1,6 +1,7 @@
 //! Credential registry trait for looking up authentication data.
 
 use crate::error::ProxyError;
+use crate::maybe_send::{MaybeSend, MaybeSync};
 use crate::types::{RoleConfig, StoredCredential};
 use std::future::Future;
 
@@ -10,16 +11,16 @@ use std::future::Future;
 ///
 /// Temporary credentials are resolved via a [`TemporaryCredentialResolver`](crate::auth::TemporaryCredentialResolver)
 /// rather than stored here.
-pub trait CredentialRegistry: Clone + Send + Sync + 'static {
+pub trait CredentialRegistry: Clone + MaybeSend + MaybeSync + 'static {
     /// Look up a long-lived credential by its access key ID.
     fn get_credential(
         &self,
         access_key_id: &str,
-    ) -> impl Future<Output = Result<Option<StoredCredential>, ProxyError>> + Send;
+    ) -> impl Future<Output = Result<Option<StoredCredential>, ProxyError>> + MaybeSend;
 
     /// Look up a role by its identifier.
     fn get_role(
         &self,
         role_id: &str,
-    ) -> impl Future<Output = Result<Option<RoleConfig>, ProxyError>> + Send;
+    ) -> impl Future<Output = Result<Option<RoleConfig>, ProxyError>> + MaybeSend;
 }


### PR DESCRIPTION
## Summary
- Changes `BucketRegistry` and `CredentialRegistry` trait bounds from `Send + Sync` to `MaybeSend + MaybeSync`
- Changes future return bounds from `+ Send` to `+ MaybeSend`
- Allows WASM implementations to use `!Send` types (like `worker::Fetch` and the CF Cache API) directly

This eliminates the painful `spawn_local` + oneshot channel bridge pattern that every CF Workers consumer must use when implementing these traits.

## Test plan
- [x] `cargo test` passes (all native tests)
- [x] `cargo check --target wasm32-unknown-unknown -p multistore-cf-workers` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)