### PR TITLE
refactor: make Body an associated type on ProxyBackend

### DIFF
--- a/crates/cf-workers/src/backend.rs
+++ b/crates/cf-workers/src/backend.rs
@@ -31,17 +31,14 @@ pub struct WorkerBackend;
 
 impl ProxyBackend for WorkerBackend {
     type ResponseBody = web_sys::Response;
+    type Body = JsBody;
 
-    async fn forward<Body: 'static>(
+    async fn forward(
         &self,
         request: ForwardRequest,
-        body: Body,
+        body: JsBody,
     ) -> Result<ForwardResponse<Self::ResponseBody>, ProxyError> {
-        // Downcast to the concrete JsBody type used by the Workers runtime.
-        let any_body: Box<dyn std::any::Any> = Box::new(body);
-        let js_body = any_body
-            .downcast::<JsBody>()
-            .map_err(|_| ProxyError::Internal("unexpected body type".into()))?;
+        let js_body = body;
 
         // Build web_sys::RequestInit.
         let init = web_sys::RequestInit::new();

--- a/crates/core/src/backend/mod.rs
+++ b/crates/core/src/backend/mod.rs
@@ -45,12 +45,15 @@ pub trait ProxyBackend: Clone + MaybeSend + MaybeSync + 'static {
     /// The streaming body type in forwarded backend responses.
     type ResponseBody: MaybeSend + 'static;
 
+    /// The request body type accepted by [`forward()`](Self::forward).
+    type Body: MaybeSend + 'static;
+
     /// Execute a presigned [`ForwardRequest`] against the backend and return
     /// the response with a streaming body.
-    fn forward<Body: MaybeSend + 'static>(
+    fn forward(
         &self,
         request: ForwardRequest,
-        body: Body,
+        body: Self::Body,
     ) -> impl Future<Output = Result<ForwardResponse<Self::ResponseBody>, ProxyError>> + MaybeSend;
 
     /// Create a [`PaginatedListStore`] for the given bucket configuration.

--- a/crates/core/src/proxy.rs
+++ b/crates/core/src/proxy.rs
@@ -223,15 +223,14 @@ where
     ///     GatewayResponse::Forward(resp) => stream_response(resp),
     /// }
     /// ```
-    pub async fn handle_request<Body, CF, Fut, E>(
+    pub async fn handle_request<CF, Fut, E>(
         &self,
         req: &RequestInfo<'_>,
-        body: Body,
+        body: B::Body,
         collect_body: CF,
     ) -> GatewayResponse<B::ResponseBody>
     where
-        Body: MaybeSend + 'static,
-        CF: FnOnce(Body) -> Fut,
+        CF: FnOnce(B::Body) -> Fut,
         Fut: std::future::Future<Output = Result<Bytes, E>>,
         E: std::fmt::Display,
     {
@@ -969,11 +968,12 @@ mod tests {
 
     impl ProxyBackend for MockBackend {
         type ResponseBody = ();
+        type Body = ();
 
-        async fn forward<Body: MaybeSend + 'static>(
+        async fn forward(
             &self,
             _request: ForwardRequest,
-            _body: Body,
+            _body: (),
         ) -> Result<ForwardResponse<()>, ProxyError> {
             unimplemented!("not needed for resolve_request tests")
         }

--- a/examples/lambda/src/client.rs
+++ b/examples/lambda/src/client.rs
@@ -48,11 +48,12 @@ async fn body_to_bytes(body: Body) -> Result<Bytes, Box<dyn std::error::Error>> 
 
 impl ProxyBackend for LambdaBackend {
     type ResponseBody = Body;
+    type Body = Body;
 
-    async fn forward<B: Send + 'static>(
+    async fn forward(
         &self,
         request: ForwardRequest,
-        body: B,
+        body: Body,
     ) -> Result<ForwardResponse<Self::ResponseBody>, ProxyError> {
         let mut req_builder = self
             .client
@@ -64,12 +65,7 @@ impl ProxyBackend for LambdaBackend {
 
         // Attach body for PUT requests
         if request.method == http::Method::PUT {
-            // Downcast to the concrete lambda_http::Body type used by the Lambda runtime.
-            let any_body: Box<dyn std::any::Any> = Box::new(body);
-            let lambda_body = any_body
-                .downcast::<Body>()
-                .map_err(|_| ProxyError::Internal("unexpected body type".into()))?;
-            let bytes = body_to_bytes(*lambda_body)
+            let bytes = body_to_bytes(body)
                 .await
                 .map_err(|e| ProxyError::Internal(format!("failed to read PUT body: {e}")))?;
             req_builder = req_builder.body(bytes);

--- a/examples/server/src/client.rs
+++ b/examples/server/src/client.rs
@@ -47,11 +47,12 @@ impl Default for ServerBackend {
 
 impl ProxyBackend for ServerBackend {
     type ResponseBody = reqwest::Response;
+    type Body = axum::body::Body;
 
-    async fn forward<Body: Send + 'static>(
+    async fn forward(
         &self,
         request: ForwardRequest,
-        body: Body,
+        body: axum::body::Body,
     ) -> Result<ForwardResponse<Self::ResponseBody>, ProxyError> {
         let mut req_builder = self
             .client
@@ -63,12 +64,7 @@ impl ProxyBackend for ServerBackend {
 
         // Attach streaming body for PUT
         if request.method == http::Method::PUT {
-            // Downcast to the concrete axum::body::Body type used by the server runtime.
-            let any_body: Box<dyn std::any::Any> = Box::new(body);
-            let axum_body = any_body
-                .downcast::<axum::body::Body>()
-                .map_err(|_| ProxyError::Internal("unexpected body type".into()))?;
-            let body_stream = BodyStream::new(*axum_body)
+            let body_stream = BodyStream::new(body)
                 .try_filter_map(|frame| async move { Ok(frame.into_data().ok()) });
             req_builder = req_builder.body(reqwest::Body::wrap_stream(body_stream));
         }


### PR DESCRIPTION
## Summary
- Replaces the generic `Body` parameter on `forward()` with an associated `type Body` on `ProxyBackend`
- Eliminates runtime downcasts via `Box<dyn Any>` — body type mismatches are now caught at compile time
- Updates all three backend implementations: `WorkerBackend`, `ServerBackend`, `LambdaBackend`

## Test plan
- [x] `cargo test -p multistore` — all tests pass
- [x] `cargo check --target wasm32-unknown-unknown -p multistore-cf-workers` passes
- [x] `cargo check -p multistore-server` passes
- [x] `cargo check -p multistore-lambda` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)