### PR TITLE
perf(sts): make JwksCache cheaply cloneable

### DIFF
--- a/crates/sts/src/jwks.rs
+++ b/crates/sts/src/jwks.rs
@@ -1,7 +1,7 @@
 //! JWKS fetching and JWT verification.
 
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
@@ -224,23 +224,30 @@ pub fn verify_token(
 ///
 /// Uses `DateTime<Utc>` instead of `std::time::Instant` for WASM compatibility
 /// (`Instant` panics on `wasm32-unknown-unknown`).
+type JwksEntries = Arc<Mutex<HashMap<String, (DateTime<Utc>, JwksResponse)>>>;
+
+#[derive(Clone)]
 pub struct JwksCache {
     client: reqwest::Client,
     ttl: Duration,
     failure_ttl: Duration,
-    entries: Mutex<HashMap<String, (DateTime<Utc>, JwksResponse)>>,
-    failures: Mutex<HashMap<String, DateTime<Utc>>>,
+    entries: JwksEntries,
+    failures: Arc<Mutex<HashMap<String, DateTime<Utc>>>>,
 }
 
 impl JwksCache {
     /// Create a new cache with the given TTL and HTTP client.
+    ///
+    /// Cloning a `JwksCache` is cheap and shares the underlying cache state,
+    /// so a single instance can be stored in a `OnceLock`/`Arc` and cloned
+    /// per request without losing TTL benefits.
     pub fn new(client: reqwest::Client, ttl: Duration) -> Self {
         Self {
             client,
             ttl,
             failure_ttl: Duration::from_secs(30),
-            entries: Mutex::new(HashMap::new()),
-            failures: Mutex::new(HashMap::new()),
+            entries: Arc::new(Mutex::new(HashMap::new())),
+            failures: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 


### PR DESCRIPTION
## What I'm changing

`JwksCache` previously held its `entries` and `failures` maps directly (`Mutex<HashMap<...>>`), so it wasn't `Clone`. Callers that wanted to hand a cache to per-request handlers either had to wrap the whole cache in an external `Arc` at every call site or construct a fresh cache per request — the latter silently defeats the TTL, since each new instance starts with an empty map and re-fetches JWKS on every call.

This change makes `JwksCache` itself `Clone` with shared state, so a single instance can live in a `OnceLock`/`Arc` and be cloned freely (e.g. once per request) without losing cache hits.

## How I did it

- Wrapped `entries` and `failures` in `Arc<Mutex<…>>` and derived `Clone` on `JwksCache`. Cloning the struct now bumps the `Arc` refcounts and shares the underlying maps.
- Added a doc note on `JwksCache::new` explaining the shared-state semantics so future callers don't reach for an outer `Arc<JwksCache>`.
- Extracted `type JwksEntries = Arc<Mutex<HashMap<String, (DateTime<Utc>, JwksResponse)>>>` to satisfy `clippy::type_complexity` on the new field type.

## Test plan

- [x] `cargo clippy -p multistore-sts` — no warnings
- [x] `cargo fmt` — clean