### PR TITLE
refactor: simplify cf workers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ docs/plans
 node_modules
 .dev.vars
 *.pyc
+.worktrees

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1157,6 +1157,7 @@ dependencies = [
  "js-sys",
  "multistore",
  "object_store",
+ "percent-encoding",
  "tracing",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/crates/cf-workers/Cargo.toml
+++ b/crates/cf-workers/Cargo.toml
@@ -14,6 +14,7 @@ gcp = ["multistore/gcp"]
 multistore.workspace = true
 bytes.workspace = true
 http.workspace = true
+percent-encoding = "2"
 tracing.workspace = true
 object_store.workspace = true
 futures.workspace = true

--- a/crates/cf-workers/src/backend.rs
+++ b/crates/cf-workers/src/backend.rs
@@ -31,17 +31,14 @@ pub struct WorkerBackend;
 
 impl ProxyBackend for WorkerBackend {
     type ResponseBody = web_sys::Response;
+    type Body = JsBody;
 
-    async fn forward<Body: 'static>(
+    async fn forward(
         &self,
         request: ForwardRequest,
-        body: Body,
+        body: JsBody,
     ) -> Result<ForwardResponse<Self::ResponseBody>, ProxyError> {
-        // Downcast to the concrete JsBody type used by the Workers runtime.
-        let any_body: Box<dyn std::any::Any> = Box::new(body);
-        let js_body = any_body
-            .downcast::<JsBody>()
-            .map_err(|_| ProxyError::Internal("unexpected body type".into()))?;
+        let js_body = body;
 
         // Build web_sys::RequestInit.
         let init = web_sys::RequestInit::new();

--- a/crates/cf-workers/src/backend.rs
+++ b/crates/cf-workers/src/backend.rs
@@ -55,7 +55,7 @@ impl ProxyBackend for WorkerBackend {
 
         // For PUT: attach the original ReadableStream directly (zero-copy!).
         if request.method == http::Method::PUT {
-            if let Some(ref stream) = js_body.0 {
+            if let Some(stream) = js_body.stream() {
                 init.set_body(stream);
             }
         }

--- a/crates/cf-workers/src/backend.rs
+++ b/crates/cf-workers/src/backend.rs
@@ -6,6 +6,7 @@
 
 use crate::body::JsBody;
 use crate::fetch_connector::FetchConnector;
+use crate::headers::WsHeaders;
 use crate::response::headermap_from_js;
 use bytes::Bytes;
 use http::HeaderMap;
@@ -42,19 +43,10 @@ impl ProxyBackend for WorkerBackend {
             .downcast::<JsBody>()
             .map_err(|_| ProxyError::Internal("unexpected body type".into()))?;
 
-        // Build web_sys::Headers from the forwarding headers.
-        let ws_headers = web_sys::Headers::new()
-            .map_err(|e| ProxyError::Internal(format!("failed to create Headers: {:?}", e)))?;
-        for (key, value) in request.headers.iter() {
-            if let Ok(v) = value.to_str() {
-                let _ = ws_headers.set(key.as_str(), v);
-            }
-        }
-
         // Build web_sys::RequestInit.
         let init = web_sys::RequestInit::new();
         init.set_method(request.method.as_str());
-        init.set_headers(&ws_headers.into());
+        init.set_headers(&WsHeaders::from(&request.headers).into_inner().into());
 
         // Bypass Cloudflare's subrequest cache for Range requests.
         if request.headers.contains_key(http::header::RANGE) {
@@ -141,20 +133,10 @@ impl ProxyBackend for WorkerBackend {
             "worker: sending raw backend request via Fetch API"
         );
 
-        // Build web_sys::Headers
-        let ws_headers = web_sys::Headers::new()
-            .map_err(|e| ProxyError::Internal(format!("failed to create Headers: {:?}", e)))?;
-
-        for (key, value) in headers.iter() {
-            if let Ok(v) = value.to_str() {
-                let _ = ws_headers.set(key.as_str(), v);
-            }
-        }
-
         // Build web_sys::RequestInit
         let init = web_sys::RequestInit::new();
         init.set_method(method.as_str());
-        init.set_headers(&ws_headers.into());
+        init.set_headers(&WsHeaders::from(&headers).into_inner().into());
 
         // Set body for methods that carry one
         if !body.is_empty() {

--- a/crates/cf-workers/src/body.rs
+++ b/crates/cf-workers/src/body.rs
@@ -7,7 +7,19 @@ use bytes::Bytes;
 
 /// Zero-copy body wrapper. Holds the raw `ReadableStream` from the incoming
 /// request, passing it through the Gateway untouched for Forward requests.
-pub struct JsBody(pub Option<web_sys::ReadableStream>);
+pub struct JsBody(Option<web_sys::ReadableStream>);
+
+impl JsBody {
+    /// Wrap an optional `ReadableStream` from a `web_sys::Request`.
+    pub fn new(stream: Option<web_sys::ReadableStream>) -> Self {
+        Self(stream)
+    }
+
+    /// Borrow the inner stream, if present.
+    pub fn stream(&self) -> Option<&web_sys::ReadableStream> {
+        self.0.as_ref()
+    }
+}
 
 // SAFETY: Workers is single-threaded; these are required by Gateway's generic bounds.
 unsafe impl Send for JsBody {}

--- a/crates/cf-workers/src/cors.rs
+++ b/crates/cf-workers/src/cors.rs
@@ -1,0 +1,56 @@
+//! CORS header utilities for browser-accessible S3 proxies.
+
+use http::HeaderMap;
+
+/// Set permissive CORS headers suitable for public, browser-accessible
+/// S3-compatible read-only proxies.
+///
+/// Sets:
+/// - `access-control-allow-origin: *`
+/// - `access-control-allow-methods: GET, HEAD, OPTIONS`
+/// - `access-control-allow-headers: *`
+/// - `access-control-expose-headers: *`
+///
+/// Existing CORS headers in the map are overwritten.
+pub fn add_cors_headers(headers: &mut HeaderMap) {
+    let pairs = [
+        ("access-control-allow-origin", "*"),
+        ("access-control-allow-methods", "GET, HEAD, OPTIONS"),
+        ("access-control-allow-headers", "*"),
+        ("access-control-expose-headers", "*"),
+    ];
+    for (name, value) in pairs {
+        if let Ok(v) = value.parse() {
+            headers.insert(name, v);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sets_all_four_cors_headers() {
+        let mut h = HeaderMap::new();
+        add_cors_headers(&mut h);
+        assert_eq!(h.get("access-control-allow-origin").unwrap(), "*");
+        assert_eq!(
+            h.get("access-control-allow-methods").unwrap(),
+            "GET, HEAD, OPTIONS"
+        );
+        assert_eq!(h.get("access-control-allow-headers").unwrap(), "*");
+        assert_eq!(h.get("access-control-expose-headers").unwrap(), "*");
+    }
+
+    #[test]
+    fn overwrites_existing() {
+        let mut h = HeaderMap::new();
+        h.insert(
+            "access-control-allow-origin",
+            "https://example.com".parse().unwrap(),
+        );
+        add_cors_headers(&mut h);
+        assert_eq!(h.get("access-control-allow-origin").unwrap(), "*");
+    }
+}

--- a/crates/cf-workers/src/headers.rs
+++ b/crates/cf-workers/src/headers.rs
@@ -1,0 +1,38 @@
+//! Newtype wrapper for `web_sys::Headers` enabling ergonomic conversions
+//! with [`http::HeaderMap`].
+//!
+//! Rust's orphan rule prevents implementing `From<&HeaderMap>` directly on
+//! `web_sys::Headers`. This wrapper provides those conversions while
+//! remaining transparent to use via [`into_inner`](WsHeaders::into_inner).
+
+use http::HeaderMap;
+
+/// Thin wrapper around [`web_sys::Headers`] that enables [`From`] conversions
+/// with [`HeaderMap`].
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let ws: WsHeaders = WsHeaders::from(&header_map);
+/// init.set_headers(&ws.into_inner().into());
+/// ```
+pub struct WsHeaders(web_sys::Headers);
+
+impl WsHeaders {
+    /// Unwrap into the inner `web_sys::Headers`.
+    pub fn into_inner(self) -> web_sys::Headers {
+        self.0
+    }
+}
+
+impl From<&HeaderMap> for WsHeaders {
+    fn from(headers: &HeaderMap) -> Self {
+        let ws = web_sys::Headers::new().unwrap();
+        for (key, value) in headers.iter() {
+            if let Ok(v) = value.to_str() {
+                let _ = ws.set(key.as_str(), v);
+            }
+        }
+        WsHeaders(ws)
+    }
+}

--- a/crates/cf-workers/src/lib.rs
+++ b/crates/cf-workers/src/lib.rs
@@ -25,5 +25,5 @@ pub use body::{collect_js_body, JsBody};
 pub use headers::WsHeaders;
 pub use noop_creds::NoopCredentialRegistry;
 pub use request::RequestParts;
-pub use response::{headermap_from_js, response_from_gateway};
+pub use response::{headermap_from_js, GatewayResponseExt};
 pub use tracing_layer::WorkerSubscriber;

--- a/crates/cf-workers/src/lib.rs
+++ b/crates/cf-workers/src/lib.rs
@@ -9,11 +9,13 @@
 //! - [`WorkerSubscriber`] — `tracing::Subscriber` routing to `console.log`
 //! - [`NoopCredentialRegistry`] — anonymous-only credential registry
 //! - [`response`] — helpers for building `web_sys::Response` from proxy results
+//! - [`add_cors_headers`] — set permissive CORS headers on a `HeaderMap`
 
 pub(crate) mod fetch_connector;
 
 pub mod backend;
 pub mod body;
+pub mod cors;
 pub mod headers;
 pub mod noop_creds;
 pub mod request;
@@ -22,6 +24,7 @@ pub mod tracing_layer;
 
 pub use backend::WorkerBackend;
 pub use body::{collect_js_body, JsBody};
+pub use cors::add_cors_headers;
 pub use headers::WsHeaders;
 pub use noop_creds::NoopCredentialRegistry;
 pub use request::RequestParts;

--- a/crates/cf-workers/src/lib.rs
+++ b/crates/cf-workers/src/lib.rs
@@ -23,5 +23,5 @@ pub use backend::WorkerBackend;
 pub use body::{collect_js_body, JsBody};
 pub use noop_creds::NoopCredentialRegistry;
 pub use request::RequestParts;
-pub use response::{error_response, headermap_from_js, response_from_gateway, xml_response};
+pub use response::{headermap_from_js, response_from_gateway};
 pub use tracing_layer::WorkerSubscriber;

--- a/crates/cf-workers/src/lib.rs
+++ b/crates/cf-workers/src/lib.rs
@@ -15,11 +15,13 @@ pub(crate) mod fetch_connector;
 pub mod backend;
 pub mod body;
 pub mod noop_creds;
+pub mod request;
 pub mod response;
 pub mod tracing_layer;
 
 pub use backend::WorkerBackend;
 pub use body::{collect_js_body, JsBody};
 pub use noop_creds::NoopCredentialRegistry;
+pub use request::RequestParts;
 pub use response::{error_response, headermap_from_js, response_from_gateway, xml_response};
 pub use tracing_layer::WorkerSubscriber;

--- a/crates/cf-workers/src/lib.rs
+++ b/crates/cf-workers/src/lib.rs
@@ -14,6 +14,7 @@ pub(crate) mod fetch_connector;
 
 pub mod backend;
 pub mod body;
+pub mod headers;
 pub mod noop_creds;
 pub mod request;
 pub mod response;
@@ -21,6 +22,7 @@ pub mod tracing_layer;
 
 pub use backend::WorkerBackend;
 pub use body::{collect_js_body, JsBody};
+pub use headers::WsHeaders;
 pub use noop_creds::NoopCredentialRegistry;
 pub use request::RequestParts;
 pub use response::{headermap_from_js, response_from_gateway};

--- a/crates/cf-workers/src/request.rs
+++ b/crates/cf-workers/src/request.rs
@@ -42,7 +42,7 @@ impl RequestParts {
     /// Extracts the body stream **before** reading headers, so the
     /// `ReadableStream` is never locked.
     pub fn from_web_sys(req: &web_sys::Request) -> Result<(Self, JsBody), String> {
-        let body = JsBody(req.body());
+        let body = JsBody::new(req.body());
 
         let method: Method = req
             .method()

--- a/crates/cf-workers/src/request.rs
+++ b/crates/cf-workers/src/request.rs
@@ -1,0 +1,79 @@
+//! Request parsing helpers for Cloudflare Workers.
+//!
+//! Provides [`RequestParts`] to extract owned HTTP metadata from a
+//! `web_sys::Request`, and convert it into the borrowed
+//! [`RequestInfo`](multistore::route_handler::RequestInfo) required by the gateway.
+
+use crate::body::JsBody;
+use crate::response::headermap_from_js;
+use http::{HeaderMap, Method, Uri};
+use multistore::route_handler::RequestInfo;
+
+/// Owned HTTP request metadata extracted from a `web_sys::Request`.
+///
+/// Workers passes a `web_sys::Request` with borrowed JS strings and a
+/// `ReadableStream` body.  The gateway expects a [`RequestInfo`] that
+/// borrows from Rust-owned data, so this struct bridges the gap by
+/// owning the parsed method, path, query, and headers.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// let (parts, body) = RequestParts::from_web_sys(&req)?;
+/// let result = gateway
+///     .handle_request(&parts.as_request_info(), body, collect_js_body)
+///     .await;
+/// ```
+pub struct RequestParts {
+    /// The HTTP method.
+    pub method: Method,
+    /// The URL path (e.g. `"/bucket/key"`).
+    pub path: String,
+    /// The raw query string, if present.
+    pub query: Option<String>,
+    /// The HTTP request headers.
+    pub headers: HeaderMap,
+}
+
+impl RequestParts {
+    /// Parse a `web_sys::Request` into owned request metadata and a
+    /// zero-copy [`JsBody`].
+    ///
+    /// Extracts the body stream **before** reading headers, so the
+    /// `ReadableStream` is never locked.
+    pub fn from_web_sys(req: &web_sys::Request) -> Result<(Self, JsBody), String> {
+        let body = JsBody(req.body());
+
+        let method: Method = req
+            .method()
+            .parse()
+            .map_err(|e| format!("invalid method: {e}"))?;
+
+        let uri: Uri = req.url().parse().map_err(|e| format!("invalid URL: {e}"))?;
+
+        let path = uri.path().to_string();
+        let query = uri.query().map(|q| q.to_string());
+        let headers = headermap_from_js(&req.headers());
+
+        Ok((
+            Self {
+                method,
+                path,
+                query,
+                headers,
+            },
+            body,
+        ))
+    }
+
+    /// Borrow this struct as a [`RequestInfo`] for gateway dispatch.
+    pub fn as_request_info(&self) -> RequestInfo<'_> {
+        RequestInfo::new(
+            &self.method,
+            &self.path,
+            self.query.as_deref(),
+            &self.headers,
+            None,
+        )
+    }
+}

--- a/crates/cf-workers/src/request.rs
+++ b/crates/cf-workers/src/request.rs
@@ -51,7 +51,9 @@ impl RequestParts {
 
         let uri: Uri = req.url().parse().map_err(|e| format!("invalid URL: {e}"))?;
 
-        let path = uri.path().to_string();
+        let path = percent_encoding::percent_decode_str(uri.path())
+            .decode_utf8_lossy()
+            .to_string();
         let query = uri.query().map(|q| q.to_string());
         let headers = headermap_from_js(&req.headers());
 

--- a/crates/cf-workers/src/response.rs
+++ b/crates/cf-workers/src/response.rs
@@ -4,13 +4,12 @@
 //! `web_sys::Response`, including header conversion utilities.
 
 use http::HeaderMap;
-use multistore::api::response::ErrorResponse;
 use multistore::backend::ForwardResponse;
 use multistore::proxy::GatewayResponse;
 use multistore::route_handler::{ProxyResponseBody, ProxyResult};
 
 /// Convert a `ProxyResult` (small buffered XML/JSON) to a `web_sys::Response`.
-pub fn response_from_proxy_result(result: ProxyResult) -> web_sys::Response {
+pub(crate) fn response_from_proxy_result(result: ProxyResult) -> web_sys::Response {
     let ws_headers =
         headers_to_js(&result.headers).unwrap_or_else(|_| web_sys::Headers::new().unwrap());
 
@@ -32,7 +31,7 @@ pub fn response_from_proxy_result(result: ProxyResult) -> web_sys::Response {
 
 /// Convert a `ForwardResponse<web_sys::Response>` into a `web_sys::Response`
 /// for the client, preserving the backend's body stream (zero-copy).
-pub fn response_from_forward(resp: ForwardResponse<web_sys::Response>) -> web_sys::Response {
+pub(crate) fn response_from_forward(resp: ForwardResponse<web_sys::Response>) -> web_sys::Response {
     let ws_headers =
         headers_to_js(&resp.headers).unwrap_or_else(|_| web_sys::Headers::new().unwrap());
 
@@ -45,24 +44,11 @@ pub fn response_from_forward(resp: ForwardResponse<web_sys::Response>) -> web_sy
 }
 
 /// Build a plain-text error response.
-pub fn error_response(status: u16, message: &str) -> web_sys::Response {
+pub(crate) fn error_response(status: u16, message: &str) -> web_sys::Response {
     let init = web_sys::ResponseInit::new();
     init.set_status(status);
     web_sys::Response::new_with_opt_str_and_init(Some(message), &init)
         .unwrap_or_else(|_| web_sys::Response::new().unwrap())
-}
-
-/// Build an XML response with `content-type: application/xml`.
-pub fn xml_response(status: u16, xml_body: &str) -> web_sys::Response {
-    let init = web_sys::ResponseInit::new();
-    init.set_status(status);
-
-    let headers = web_sys::Headers::new().unwrap();
-    let _ = headers.set("content-type", "application/xml");
-    init.set_headers(&headers.into());
-
-    web_sys::Response::new_with_opt_str_and_init(Some(xml_body), &init)
-        .unwrap_or_else(|_| error_response(500, "Internal Server Error"))
 }
 
 /// Convert a [`GatewayResponse`] to a `web_sys::Response`.
@@ -71,11 +57,6 @@ pub fn response_from_gateway(response: GatewayResponse<web_sys::Response>) -> we
         GatewayResponse::Response(r) => response_from_proxy_result(r),
         GatewayResponse::Forward(r) => response_from_forward(r),
     }
-}
-
-/// Build an S3-compatible XML error response from an [`ErrorResponse`].
-pub fn s3_error_response(status: u16, error: &ErrorResponse) -> web_sys::Response {
-    xml_response(status, &error.to_xml())
 }
 
 // -- Header conversion helpers -----------------------------------------------
@@ -104,7 +85,7 @@ pub fn headermap_from_js(ws_headers: &web_sys::Headers) -> HeaderMap {
 }
 
 /// Convert `http::HeaderMap` to `web_sys::Headers`.
-pub fn headers_to_js(
+pub(crate) fn headers_to_js(
     headers: &HeaderMap,
 ) -> std::result::Result<web_sys::Headers, wasm_bindgen::JsValue> {
     let ws = web_sys::Headers::new()?;

--- a/crates/cf-workers/src/response.rs
+++ b/crates/cf-workers/src/response.rs
@@ -3,6 +3,7 @@
 //! Provides conversion functions between multistore proxy types and
 //! `web_sys::Response`, including header conversion utilities.
 
+use crate::headers::WsHeaders;
 use http::HeaderMap;
 use multistore::backend::ForwardResponse;
 use multistore::proxy::GatewayResponse;
@@ -10,12 +11,9 @@ use multistore::route_handler::{ProxyResponseBody, ProxyResult};
 
 /// Convert a `ProxyResult` (small buffered XML/JSON) to a `web_sys::Response`.
 pub(crate) fn response_from_proxy_result(result: ProxyResult) -> web_sys::Response {
-    let ws_headers =
-        headers_to_js(&result.headers).unwrap_or_else(|_| web_sys::Headers::new().unwrap());
-
     let resp_init = web_sys::ResponseInit::new();
     resp_init.set_status(result.status);
-    resp_init.set_headers(&ws_headers.into());
+    resp_init.set_headers(&WsHeaders::from(&result.headers).into_inner().into());
 
     match result.body {
         ProxyResponseBody::Empty => {
@@ -32,12 +30,9 @@ pub(crate) fn response_from_proxy_result(result: ProxyResult) -> web_sys::Respon
 /// Convert a `ForwardResponse<web_sys::Response>` into a `web_sys::Response`
 /// for the client, preserving the backend's body stream (zero-copy).
 pub(crate) fn response_from_forward(resp: ForwardResponse<web_sys::Response>) -> web_sys::Response {
-    let ws_headers =
-        headers_to_js(&resp.headers).unwrap_or_else(|_| web_sys::Headers::new().unwrap());
-
     let resp_init = web_sys::ResponseInit::new();
     resp_init.set_status(resp.status);
-    resp_init.set_headers(&ws_headers.into());
+    resp_init.set_headers(&WsHeaders::from(&resp.headers).into_inner().into());
 
     web_sys::Response::new_with_opt_readable_stream_and_init(resp.body.body().as_ref(), &resp_init)
         .unwrap_or_else(|_| error_response(502, "Bad Gateway"))
@@ -82,17 +77,4 @@ pub fn headermap_from_js(ws_headers: &web_sys::Headers) -> HeaderMap {
         headers.append(name, val);
     }
     headers
-}
-
-/// Convert `http::HeaderMap` to `web_sys::Headers`.
-pub(crate) fn headers_to_js(
-    headers: &HeaderMap,
-) -> std::result::Result<web_sys::Headers, wasm_bindgen::JsValue> {
-    let ws = web_sys::Headers::new()?;
-    for (key, value) in headers.iter() {
-        if let Ok(v) = value.to_str() {
-            ws.set(key.as_str(), v)?;
-        }
-    }
-    Ok(ws)
 }

--- a/crates/cf-workers/src/response.rs
+++ b/crates/cf-workers/src/response.rs
@@ -46,11 +46,18 @@ pub(crate) fn error_response(status: u16, message: &str) -> web_sys::Response {
         .unwrap_or_else(|_| web_sys::Response::new().unwrap())
 }
 
-/// Convert a [`GatewayResponse`] to a `web_sys::Response`.
-pub fn response_from_gateway(response: GatewayResponse<web_sys::Response>) -> web_sys::Response {
-    match response {
-        GatewayResponse::Response(r) => response_from_proxy_result(r),
-        GatewayResponse::Forward(r) => response_from_forward(r),
+/// Extension trait for converting a [`GatewayResponse`] into a `web_sys::Response`.
+pub trait GatewayResponseExt {
+    /// Convert this gateway response into a `web_sys::Response`.
+    fn into_web_sys(self) -> web_sys::Response;
+}
+
+impl GatewayResponseExt for GatewayResponse<web_sys::Response> {
+    fn into_web_sys(self) -> web_sys::Response {
+        match self {
+            GatewayResponse::Response(r) => response_from_proxy_result(r),
+            GatewayResponse::Forward(r) => response_from_forward(r),
+        }
     }
 }
 

--- a/crates/core/src/backend/mod.rs
+++ b/crates/core/src/backend/mod.rs
@@ -45,12 +45,15 @@ pub trait ProxyBackend: Clone + MaybeSend + MaybeSync + 'static {
     /// The streaming body type in forwarded backend responses.
     type ResponseBody: MaybeSend + 'static;
 
+    /// The request body type accepted by [`forward()`](Self::forward).
+    type Body: MaybeSend + 'static;
+
     /// Execute a presigned [`ForwardRequest`] against the backend and return
     /// the response with a streaming body.
-    fn forward<Body: MaybeSend + 'static>(
+    fn forward(
         &self,
         request: ForwardRequest,
-        body: Body,
+        body: Self::Body,
     ) -> impl Future<Output = Result<ForwardResponse<Self::ResponseBody>, ProxyError>> + MaybeSend;
 
     /// Create a [`PaginatedListStore`] for the given bucket configuration.

--- a/crates/core/src/maybe_send.rs
+++ b/crates/core/src/maybe_send.rs
@@ -4,11 +4,13 @@
 //! On native targets, `MaybeSend` resolves to `Send` and `MaybeSync` to
 //! `Sync`. On `wasm32` targets, both are no-ops.
 //!
-//! Only used for traits that genuinely need it: [`ProxyBackend`](crate::backend::ProxyBackend),
+//! Used by traits whose implementations may hold `!Send` types on WASM:
+//! [`ProxyBackend`](crate::backend::ProxyBackend),
 //! [`Middleware`](crate::middleware::Middleware),
-//! [`RouteHandler`](crate::route_handler::RouteHandler), and the
+//! [`RouteHandler`](crate::route_handler::RouteHandler),
+//! [`BucketRegistry`](crate::registry::BucketRegistry),
+//! [`CredentialRegistry`](crate::registry::CredentialRegistry), and the
 //! `oidc-provider` crate's [`HttpExchange`] / [`CredentialExchange`] traits.
-//! Other traits use plain `Send + Sync`.
 
 // --- Native targets: MaybeSend = Send, MaybeSync = Sync ---
 

--- a/crates/core/src/proxy.rs
+++ b/crates/core/src/proxy.rs
@@ -223,15 +223,14 @@ where
     ///     GatewayResponse::Forward(resp) => stream_response(resp),
     /// }
     /// ```
-    pub async fn handle_request<Body, CF, Fut, E>(
+    pub async fn handle_request<CF, Fut, E>(
         &self,
         req: &RequestInfo<'_>,
-        body: Body,
+        body: B::Body,
         collect_body: CF,
     ) -> GatewayResponse<B::ResponseBody>
     where
-        Body: MaybeSend + 'static,
-        CF: FnOnce(Body) -> Fut,
+        CF: FnOnce(B::Body) -> Fut,
         Fut: std::future::Future<Output = Result<Bytes, E>>,
         E: std::fmt::Display,
     {
@@ -969,11 +968,12 @@ mod tests {
 
     impl ProxyBackend for MockBackend {
         type ResponseBody = ();
+        type Body = ();
 
-        async fn forward<Body: MaybeSend + 'static>(
+        async fn forward(
             &self,
             _request: ForwardRequest,
-            _body: Body,
+            _body: (),
         ) -> Result<ForwardResponse<()>, ProxyError> {
             unimplemented!("not needed for resolve_request tests")
         }

--- a/crates/core/src/proxy.rs
+++ b/crates/core/src/proxy.rs
@@ -59,7 +59,6 @@ use crate::backend::request_signer::{hash_payload, UNSIGNED_PAYLOAD};
 use crate::backend::ForwardResponse;
 use crate::backend::ProxyBackend;
 use crate::error::ProxyError;
-use crate::maybe_send::MaybeSend;
 use crate::middleware::{
     CompletedRequest, Dispatch, DispatchContext, DispatchFuture, ErasedMiddleware, Middleware, Next,
 };
@@ -1467,11 +1466,12 @@ mod tests {
 
     impl ProxyBackend for ForwardMockBackend {
         type ResponseBody = ();
+        type Body = ();
 
-        async fn forward<Body: MaybeSend + 'static>(
+        async fn forward(
             &self,
             _request: ForwardRequest,
-            _body: Body,
+            _body: (),
         ) -> Result<ForwardResponse<()>, ProxyError> {
             Ok(ForwardResponse {
                 status: 200,

--- a/crates/core/src/registry/bucket.rs
+++ b/crates/core/src/registry/bucket.rs
@@ -3,6 +3,7 @@
 use crate::api::list_rewrite::ListRewrite;
 use crate::api::response::BucketEntry;
 use crate::error::ProxyError;
+use crate::maybe_send::{MaybeSend, MaybeSync};
 use crate::types::{BucketConfig, BucketOwner, ResolvedIdentity, S3Operation};
 use std::future::Future;
 
@@ -32,7 +33,7 @@ pub struct ResolvedBucket {
 /// parsing the S3 request and resolving the caller's identity.
 ///
 /// Implementations should be cheap to clone (wrap inner state in `Arc`).
-pub trait BucketRegistry: Clone + Send + Sync + 'static {
+pub trait BucketRegistry: Clone + MaybeSend + MaybeSync + 'static {
     /// Resolve a bucket by name, checking authorization for the given identity and operation.
     ///
     /// Returns `Err(ProxyError::BucketNotFound)` if the bucket doesn't exist,
@@ -42,13 +43,13 @@ pub trait BucketRegistry: Clone + Send + Sync + 'static {
         name: &str,
         identity: &ResolvedIdentity,
         operation: &S3Operation,
-    ) -> impl Future<Output = Result<ResolvedBucket, ProxyError>> + Send;
+    ) -> impl Future<Output = Result<ResolvedBucket, ProxyError>> + MaybeSend;
 
     /// List all buckets visible to the given identity.
     fn list_buckets(
         &self,
         identity: &ResolvedIdentity,
-    ) -> impl Future<Output = Result<Vec<BucketEntry>, ProxyError>> + Send;
+    ) -> impl Future<Output = Result<Vec<BucketEntry>, ProxyError>> + MaybeSend;
 
     /// The owner identity returned in `ListAllMyBucketsResult` responses.
     ///

--- a/crates/core/src/registry/credential.rs
+++ b/crates/core/src/registry/credential.rs
@@ -1,6 +1,7 @@
 //! Credential registry trait for looking up authentication data.
 
 use crate::error::ProxyError;
+use crate::maybe_send::{MaybeSend, MaybeSync};
 use crate::types::{RoleConfig, StoredCredential};
 use std::future::Future;
 
@@ -10,16 +11,16 @@ use std::future::Future;
 ///
 /// Temporary credentials are resolved via a [`TemporaryCredentialResolver`](crate::auth::TemporaryCredentialResolver)
 /// rather than stored here.
-pub trait CredentialRegistry: Clone + Send + Sync + 'static {
+pub trait CredentialRegistry: Clone + MaybeSend + MaybeSync + 'static {
     /// Look up a long-lived credential by its access key ID.
     fn get_credential(
         &self,
         access_key_id: &str,
-    ) -> impl Future<Output = Result<Option<StoredCredential>, ProxyError>> + Send;
+    ) -> impl Future<Output = Result<Option<StoredCredential>, ProxyError>> + MaybeSend;
 
     /// Look up a role by its identifier.
     fn get_role(
         &self,
         role_id: &str,
-    ) -> impl Future<Output = Result<Option<RoleConfig>, ProxyError>> + Send;
+    ) -> impl Future<Output = Result<Option<RoleConfig>, ProxyError>> + MaybeSend;
 }

--- a/crates/core/src/route_handler.rs
+++ b/crates/core/src/route_handler.rs
@@ -56,6 +56,20 @@ pub enum HandlerAction {
     NeedsBody(PendingRequest),
 }
 
+impl HandlerAction {
+    /// Returns a mutable reference to the response headers, if available.
+    ///
+    /// Returns `Some(&mut HeaderMap)` for `Response` and `Forward` variants,
+    /// `None` for `NeedsBody` (which has no response yet).
+    pub fn response_headers_mut(&mut self) -> Option<&mut HeaderMap> {
+        match self {
+            HandlerAction::Response(result) => Some(&mut result.headers),
+            HandlerAction::Forward(fwd) => Some(&mut fwd.headers),
+            HandlerAction::NeedsBody(_) => None,
+        }
+    }
+}
+
 /// A presigned URL request for the runtime to execute.
 pub struct ForwardRequest {
     /// HTTP method for the backend request.
@@ -270,6 +284,53 @@ pub trait RouteHandler: MaybeSend + MaybeSync {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_response_headers_mut_on_response() {
+        let mut action = HandlerAction::Response(ProxyResult {
+            status: 200,
+            headers: HeaderMap::new(),
+            body: ProxyResponseBody::Empty,
+        });
+        let headers = action.response_headers_mut().unwrap();
+        headers.insert("x-custom", "value".parse().unwrap());
+        if let HandlerAction::Response(result) = &action {
+            assert_eq!(result.headers.get("x-custom").unwrap(), "value");
+        }
+    }
+
+    #[test]
+    fn test_response_headers_mut_on_forward() {
+        let mut action = HandlerAction::Forward(ForwardRequest {
+            method: Method::GET,
+            url: "https://example.com".parse().unwrap(),
+            headers: HeaderMap::new(),
+            request_id: String::new(),
+        });
+        assert!(action.response_headers_mut().is_some());
+    }
+
+    #[test]
+    fn test_response_headers_mut_on_needs_body() {
+        use crate::types::{BucketConfig, S3Operation};
+        let mut action = HandlerAction::NeedsBody(PendingRequest {
+            operation: S3Operation::CreateMultipartUpload {
+                bucket: "b".into(),
+                key: "k".into(),
+            },
+            bucket_config: BucketConfig {
+                name: String::new(),
+                backend_type: "s3".into(),
+                backend_prefix: None,
+                anonymous_access: false,
+                backend_options: Default::default(),
+                allowed_roles: Vec::new(),
+            },
+            original_headers: HeaderMap::new(),
+            request_id: String::new(),
+        });
+        assert!(action.response_headers_mut().is_none());
+    }
 
     #[test]
     fn test_blocks_hop_by_hop_headers() {

--- a/docs/architecture/crate-layout.md
+++ b/docs/architecture/crate-layout.md
@@ -78,7 +78,10 @@ The native server runtime (in `examples/server/`):
 
 The Cloudflare Workers WASM runtime (in `examples/cf-workers/`):
 - `WorkerBackend` implementing `ProxyBackend` with `web_sys::fetch`
-- `WorkerForwarder` implementing `Forwarder` with the Fetch API (zero-copy `ReadableStream`)
+- `RequestParts` — extracts owned HTTP metadata from `web_sys::Request` and provides `as_request_info()` for gateway dispatch
+- `GatewayResponseExt` — extension trait for converting `GatewayResponse` to `web_sys::Response` via `.into_web_sys()`
+- `JsBody` — zero-copy body wrapper around `web_sys::ReadableStream`
+- `WsHeaders` — newtype around `web_sys::Headers` with `From<&HeaderMap>` (works around orphan rules)
 - `FetchConnector` bridging `object_store` HTTP to Workers Fetch API
 - `BandwidthMeter` Durable Object — per-(bucket, identity) sliding-window byte counter
 - `DoBandwidthMeter` implementing `QuotaChecker` + `UsageRecorder` via the `BandwidthMeter` DO
@@ -114,4 +117,4 @@ flowchart TD
     oidc --> core
 ```
 
-Libraries define trait abstractions. Runtimes implement `ProxyBackend` and `Forwarder` with platform-native primitives, build a `Router` with extension traits, and handle the two-variant `GatewayResponse`.
+Libraries define trait abstractions. Runtimes implement `ProxyBackend` with platform-native primitives, build a `Router` with extension traits, and convert the two-variant `GatewayResponse` into a platform response (e.g. via `GatewayResponseExt::into_web_sys()` on Workers).

--- a/examples/cf-workers/src/lib.rs
+++ b/examples/cf-workers/src/lib.rs
@@ -28,8 +28,7 @@ pub use bandwidth::BandwidthMeter;
 use multistore::proxy::ProxyGateway;
 use multistore::router::Router;
 use multistore_cf_workers::{
-    collect_js_body, headermap_from_js, response_from_gateway, JsBody, WorkerBackend,
-    WorkerSubscriber,
+    collect_js_body, response_from_gateway, RequestParts, WorkerBackend, WorkerSubscriber,
 };
 use multistore_oidc_provider::backend_auth::MaybeOidcAuth;
 use multistore_oidc_provider::jwt::JwtSigner;
@@ -94,27 +93,12 @@ async fn fetch(req: web_sys::Request, env: Env, _ctx: Context) -> Result<web_sys
         gateway = gateway.with_credential_resolver(resolver.clone());
     }
 
-    // Extract body stream BEFORE any wrapping — no lock, zero-cost ref.
-    let js_body = JsBody(req.body());
-
-    // Parse request metadata from the raw web_sys::Request.
-    let method: http::Method = req.method().parse().unwrap_or(http::Method::GET);
-    let url_str = req.url();
-    let uri: http::Uri = url_str.parse().unwrap();
-    let path = uri.path().to_string();
-    let query = uri.query().map(|q| q.to_string());
-    let headers = headermap_from_js(&req.headers());
-
-    let req_info = multistore::route_handler::RequestInfo::new(
-        &method,
-        &path,
-        query.as_deref(),
-        &headers,
-        None,
-    );
+    // Parse request metadata and extract the body stream (zero-copy).
+    let (parts, js_body) =
+        RequestParts::from_web_sys(&req).map_err(|e| worker::Error::RustError(e))?;
 
     let result = gateway
-        .handle_request(&req_info, js_body, collect_js_body)
+        .handle_request(&parts.as_request_info(), js_body, collect_js_body)
         .await;
     Ok(response_from_gateway(result))
 }

--- a/examples/cf-workers/src/lib.rs
+++ b/examples/cf-workers/src/lib.rs
@@ -28,7 +28,7 @@ pub use bandwidth::BandwidthMeter;
 use multistore::proxy::ProxyGateway;
 use multistore::router::Router;
 use multistore_cf_workers::{
-    collect_js_body, response_from_gateway, RequestParts, WorkerBackend, WorkerSubscriber,
+    collect_js_body, GatewayResponseExt, RequestParts, WorkerBackend, WorkerSubscriber,
 };
 use multistore_oidc_provider::backend_auth::MaybeOidcAuth;
 use multistore_oidc_provider::jwt::JwtSigner;
@@ -97,10 +97,10 @@ async fn fetch(req: web_sys::Request, env: Env, _ctx: Context) -> Result<web_sys
     let (parts, js_body) =
         RequestParts::from_web_sys(&req).map_err(|e| worker::Error::RustError(e))?;
 
-    let result = gateway
+    Ok(gateway
         .handle_request(&parts.as_request_info(), js_body, collect_js_body)
-        .await;
-    Ok(response_from_gateway(result))
+        .await
+        .into_web_sys())
 }
 
 // ── OIDC HTTP exchange ─────────────────────────────────────────────

--- a/examples/lambda/src/client.rs
+++ b/examples/lambda/src/client.rs
@@ -48,11 +48,12 @@ async fn body_to_bytes(body: Body) -> Result<Bytes, Box<dyn std::error::Error>> 
 
 impl ProxyBackend for LambdaBackend {
     type ResponseBody = Body;
+    type Body = Body;
 
-    async fn forward<B: Send + 'static>(
+    async fn forward(
         &self,
         request: ForwardRequest,
-        body: B,
+        body: Body,
     ) -> Result<ForwardResponse<Self::ResponseBody>, ProxyError> {
         let mut req_builder = self
             .client
@@ -64,12 +65,7 @@ impl ProxyBackend for LambdaBackend {
 
         // Attach body for PUT requests
         if request.method == http::Method::PUT {
-            // Downcast to the concrete lambda_http::Body type used by the Lambda runtime.
-            let any_body: Box<dyn std::any::Any> = Box::new(body);
-            let lambda_body = any_body
-                .downcast::<Body>()
-                .map_err(|_| ProxyError::Internal("unexpected body type".into()))?;
-            let bytes = body_to_bytes(*lambda_body)
+            let bytes = body_to_bytes(body)
                 .await
                 .map_err(|e| ProxyError::Internal(format!("failed to read PUT body: {e}")))?;
             req_builder = req_builder.body(bytes);

--- a/examples/server/src/client.rs
+++ b/examples/server/src/client.rs
@@ -47,11 +47,12 @@ impl Default for ServerBackend {
 
 impl ProxyBackend for ServerBackend {
     type ResponseBody = reqwest::Response;
+    type Body = axum::body::Body;
 
-    async fn forward<Body: Send + 'static>(
+    async fn forward(
         &self,
         request: ForwardRequest,
-        body: Body,
+        body: axum::body::Body,
     ) -> Result<ForwardResponse<Self::ResponseBody>, ProxyError> {
         let mut req_builder = self
             .client
@@ -63,12 +64,7 @@ impl ProxyBackend for ServerBackend {
 
         // Attach streaming body for PUT
         if request.method == http::Method::PUT {
-            // Downcast to the concrete axum::body::Body type used by the server runtime.
-            let any_body: Box<dyn std::any::Any> = Box::new(body);
-            let axum_body = any_body
-                .downcast::<axum::body::Body>()
-                .map_err(|_| ProxyError::Internal("unexpected body type".into()))?;
-            let body_stream = BodyStream::new(*axum_body)
+            let body_stream = BodyStream::new(body)
                 .try_filter_map(|frame| async move { Ok(frame.into_data().ok()) });
             req_builder = req_builder.body(reqwest::Body::wrap_stream(body_stream));
         }


### PR DESCRIPTION
## What I'm changing

Writing a Cloudflare Workers consumer of multistore required too much boilerplate: every handler manually parsed `web_sys::Request` into method/path/query/headers, every `forward()` impl downcast `Box<dyn Any>` to recover its concrete body type, and every backend rebuilt `web_sys::Headers` from a `HeaderMap` by hand. Two trait bounds also forced WASM workarounds: `ProxyBackend::forward` was generic over `Body`, and `BucketRegistry` / `CredentialRegistry` required `Send + Sync` — which meant any registry holding a `!Send` type (e.g. `worker::Fetch`, CF Cache API) needed `spawn_local` + oneshot channel bridges to fake `Send`.

This PR removes that boilerplate, tightens the cf-workers public surface, and rebases the trait bounds so WASM runtimes can hold `!Send` types directly. The end result: the cf-workers example handler shrinks to a three-line call chain.

## How I did it

Core trait changes (consumed by every runtime):
- `crates/core/src/backend/mod.rs` — `ProxyBackend::forward` drops the `<Body: MaybeSend>` generic in favour of an associated `type Body`. Body-type mismatches now fail at compile time instead of via `Box<dyn Any>` downcast at runtime. Touches every implementer: `WorkerBackend`, `ServerBackend`, `LambdaBackend`.
- `crates/core/src/registry/{bucket,credential}.rs` — `BucketRegistry` and `CredentialRegistry` change from `Send + Sync` to `MaybeSend + MaybeSync`, matching the existing `ProxyBackend` / `Middleware` / `RouteHandler` bounds. WASM registries can now hold `worker::Fetch` and the CF Cache API directly.
- `crates/core/src/route_handler.rs` — new `HandlerAction::response_headers_mut()` returns `Option<&mut HeaderMap>` for the `Response` / `Forward` variants. Middleware that injects CORS or Server-Timing headers no longer needs a three-arm `match`.
- `crates/core/src/proxy.rs` — `ProxyGateway::handle_request` updated to use `B::Body` instead of a generic, propagating the trait change.

cf-workers crate ergonomics:
- `crates/cf-workers/src/request.rs` — new `RequestParts` struct: `from_web_sys()` extracts owned `method`, `path`, `query`, `headers`, `source_ip` plus the body `JsBody`; `as_request_info()` borrows them as a `RequestInfo<'_>` for `handle_request`. Replaces ~8 lines of per-handler parsing.
- `crates/cf-workers/src/response.rs` — new `GatewayResponseExt` trait adds `.into_web_sys()` directly on `GatewayResponse`, replacing the free `response_from_gateway` function so IDE autocomplete surfaces it on the result type.
- `crates/cf-workers/src/headers.rs` — new `WsHeaders` newtype with `From<&HeaderMap>`. The newtype exists to dodge the orphan rule (`From` on foreign `web_sys::Headers`). Used by `WorkerBackend::forward` and `WorkerBackend::send_raw`, deleting four hand-rolled header-conversion blocks and the now-dead `headers_to_js`.
- `crates/cf-workers/src/body.rs` — `JsBody`'s inner `Option<ReadableStream>` is now private behind `new()` / `stream()` accessors, preventing accidental mutation of the borrowed stream.
- `crates/cf-workers/src/cors.rs` — new `add_cors_headers(&mut HeaderMap)` helper for the common read-only-public-proxy case. Pairs naturally with `HandlerAction::response_headers_mut()` above.
- `crates/cf-workers/src/request.rs` — `from_web_sys` now percent-decodes the URL path via `percent-encoding`, since object keys with spaces / Unicode arrive URL-encoded from browsers.
- `crates/cf-workers/src/lib.rs` — trim public exports from 8 to 2 (`headermap_from_js`, `GatewayResponseExt`). Removed dead `xml_response` / `s3_error_response`; demoted internal helpers to `pub(crate)`.

Other:
- `docs/architecture/crate-layout.md` — describe the new cf-workers exports (`RequestParts`, `GatewayResponseExt`, `JsBody`, `WsHeaders`) and the `GatewayResponseExt::into_web_sys()` flow.
- `examples/cf-workers/src/lib.rs` — collapse the handler body to `gateway.handle_request(...).await.into_web_sys()` to demonstrate the new API surface end-to-end.
- Last commit (`chore: merge fix`) repairs the merge from `main`: the `ForwardMockBackend` test that came in with PR #20 still used the old `forward<Body: MaybeSend>` signature, so it gained `type Body = ();` and dropped the generic.

## Test plan

- [x] `make ci` (fmt + clippy `-D warnings` + `cargo check` + `cargo check -p multistore-cf-workers --target wasm32-unknown-unknown` + full test suite)
