### PR TITLE
docs: fix accuracy drift between docs and code

### DIFF
--- a/docs/architecture/crate-layout.md
+++ b/docs/architecture/crate-layout.md
@@ -4,15 +4,18 @@ The project is organized as a Cargo workspace with libraries (traits and logic) 
 
 ```
 crates/
-├── core/  (multistore)                 # Runtime-agnostic: traits, S3 parsing, SigV4, registries
-├── metering/ (multistore-metering)     # Usage metering and quota enforcement middleware
-├── sts/   (multistore-sts)             # OIDC/STS token exchange (AssumeRoleWithWebIdentity)
-└── oidc-provider/                      # Outbound OIDC provider (JWT signing, JWKS, exchange)
+├── core/          (multistore)                # Runtime-agnostic: traits, S3 parsing, SigV4, registries
+├── metering/      (multistore-metering)       # Usage metering and quota enforcement middleware
+├── sts/           (multistore-sts)            # OIDC/STS token exchange (AssumeRoleWithWebIdentity)
+├── oidc-provider/ (multistore-oidc-provider)  # Outbound OIDC provider (JWT signing, JWKS, exchange)
+├── static-config/ (multistore-static-config)  # Static config provider (buckets/roles/credentials)
+├── path-mapping/  (multistore-path-mapping)   # Hierarchical path-based backend resolution
+└── cf-workers/    (multistore-cf-workers)     # Cloudflare Workers runtime library (WASM)
 
 examples/
-├── server/ (multistore-server)         # Tokio/Hyper for container deployments
-├── lambda/ (multistore-lambda)         # AWS Lambda runtime
-└── cf-workers/ (multistore-cf-workers) # Cloudflare Workers for edge deployments
+├── server/     (multistore-server)             # Tokio/Hyper for container deployments
+├── lambda/     (multistore-lambda)             # AWS Lambda runtime
+└── cf-workers/ (multistore-cf-workers-example) # Cloudflare Workers example for edge deployments
 ```
 
 ## Crate Responsibilities
@@ -24,10 +27,9 @@ The runtime-agnostic core. Contains:
 - `Router` — Path-based route matching via `matchit` for efficient pre-dispatch
 - `RouteHandler` trait — Pluggable request interception
 - `Middleware` trait — Composable post-auth middleware for dispatch, with `after_dispatch` for post-response observation
-- `Forwarder` trait — Runtime-provided HTTP transport for backend forwarding; the core orchestrates the call so middleware can observe response metadata
 - `BucketRegistry` trait — Bucket lookup, authorization, and listing
 - `CredentialRegistry` trait — Credential and role storage
-- `ProxyBackend` trait — Runtime abstraction for store/signer/raw HTTP
+- `ProxyBackend` trait — Runtime abstraction for store/signer/raw HTTP; its `forward()` method provides backend HTTP transport, and the core orchestrates the call so middleware can observe response metadata
 - S3 request parsing, XML response building, list prefix rewriting
 - SigV4 signature verification
 - Sealed session token encryption/decryption
@@ -65,6 +67,19 @@ Outbound OIDC identity provider for backend authentication:
 - AWS credential exchange (`AwsBackendAuth` middleware)
 - Credential caching
 
+### `multistore-static-config`
+
+The built-in configuration provider (`StaticProvider`) — the only config provider shipped today:
+- Loads buckets, roles, and credentials from a single TOML or JSON file
+- Implements `BucketRegistry` and `CredentialRegistry` over the parsed config
+- Suitable for static deployments where the bucket/role/credential set is known ahead of time
+
+### `multistore-path-mapping`
+
+Hierarchical path-based backend resolution:
+- Maps request paths of the form `/{account}/{product}/{key}` to a per-(account, product) backend
+- Resolves the backend for each account/product pair from the configured mapping
+
 ### `multistore-server`
 
 The native server runtime (in `examples/server/`):
@@ -76,20 +91,26 @@ The native server runtime (in `examples/server/`):
 
 ### `multistore-cf-workers`
 
-The Cloudflare Workers WASM runtime (in `examples/cf-workers/`):
+The reusable Cloudflare Workers WASM runtime library (in `crates/cf-workers/`):
 - `WorkerBackend` implementing `ProxyBackend` with `web_sys::fetch`
 - `RequestParts` — extracts owned HTTP metadata from `web_sys::Request` and provides `as_request_info()` for gateway dispatch
 - `GatewayResponseExt` — extension trait for converting `GatewayResponse` to `web_sys::Response` via `.into_web_sys()`
 - `JsBody` — zero-copy body wrapper around `web_sys::ReadableStream`
 - `WsHeaders` — newtype around `web_sys::Headers` with `From<&HeaderMap>` (works around orphan rules)
 - `FetchConnector` bridging `object_store` HTTP to Workers Fetch API
+
+> [!WARNING]
+> This crate is excluded from the workspace `default-members` because WASM types are `!Send` and won't compile on native targets. Always build with `--target wasm32-unknown-unknown`.
+
+### `multistore-cf-workers-example`
+
+The Cloudflare Workers example deployment (in `examples/cf-workers/`). It wires the
+`multistore-cf-workers` library together with config, STS, OIDC, and metering, and adds
+example-only symbols:
 - `BandwidthMeter` Durable Object — per-(bucket, identity) sliding-window byte counter
 - `DoBandwidthMeter` implementing `QuotaChecker` + `UsageRecorder` via the `BandwidthMeter` DO
 - `CfRateLimiter` middleware for request-rate limiting via CF Rate Limiting API
 - Config loading from env vars (`PROXY_CONFIG`, `BANDWIDTH_QUOTAS`)
-
-> [!WARNING]
-> This crate is excluded from the workspace `default-members` because WASM types are `!Send` and won't compile on native targets. Always build with `--target wasm32-unknown-unknown`.
 
 ## Dependency Flow
 
@@ -99,9 +120,12 @@ flowchart TD
     metering["multistore-metering"]
     sts["multistore-sts"]
     oidc["multistore-oidc-provider"]
+    staticcfg["multistore-static-config"]
+    pathmap["multistore-path-mapping"]
+    cfworkers["multistore-cf-workers"]
     server["multistore-server"]
     lambda["multistore-lambda"]
-    workers["multistore-cf-workers"]
+    workers["multistore-cf-workers-example"]
 
     server --> core
     server --> sts
@@ -110,11 +134,15 @@ flowchart TD
     lambda --> sts
     lambda --> oidc
     workers --> core
+    workers --> cfworkers
     workers --> sts
     workers --> oidc
+    cfworkers --> core
     metering --> core
     sts --> core
     oidc --> core
+    staticcfg --> core
+    pathmap --> core
 ```
 
 Libraries define trait abstractions. Runtimes implement `ProxyBackend` with platform-native primitives, build a `Router` with extension traits, and convert the two-variant `GatewayResponse` into a platform response (e.g. via `GatewayResponseExt::into_web_sys()` on Workers).

--- a/docs/architecture/multi-runtime.md
+++ b/docs/architecture/multi-runtime.md
@@ -11,7 +11,7 @@ The proxy runs on two runtimes — a native Tokio/Hyper server for container dep
 | **HTTP client** | reqwest | `web_sys::fetch` |
 | **Streaming** | hyper `Incoming` / reqwest `bytes_stream()` | JS `ReadableStream` passthrough |
 | **Object store connector** | Default (reqwest-based) | `FetchConnector` |
-| **Backend support** | S3, Azure, GCS | S3 only |
+| **Backend support** | S3, Azure, GCS | S3, Azure, GCS via cargo features (example ships S3 only) |
 | **Config loading** | TOML file | Env var (JSON or JS object) |
 | **Threading** | Multi-threaded (`Send + Sync` required) | Single-threaded (`!Send` types allowed) |
 
@@ -26,7 +26,7 @@ The solution is conditional trait aliases defined in `multistore`:
 - On native targets: `MaybeSend` resolves to `Send`, `MaybeSync` resolves to `Sync`
 - On `wasm32`: `MaybeSend` and `MaybeSync` are blanket traits that every type implements
 
-Only traits whose wasm implementations use `!Send` types need `MaybeSend + MaybeSync`: `ProxyBackend`, `RouteHandler`, `Middleware`, `HttpExchange`, and `CredentialExchange`. Other traits like `BucketRegistry` and `CredentialRegistry` use plain `Send + Sync`.
+Traits whose wasm implementations use `!Send` types are bounded by `MaybeSend + MaybeSync`: `ProxyBackend`, `RouteHandler`, `Middleware`, `HttpExchange`, and `CredentialExchange`. The registry traits `BucketRegistry` and `CredentialRegistry` use the same conditional bounds (`Clone + MaybeSend + MaybeSync + 'static`), so they resolve to `Send + Sync` on native targets and relax to `!Send` on wasm.
 
 The `Signer` trait from `object_store` requires real `Send + Sync`, which works because `UnsignedUrlSigner` only holds `String` fields, and `object_store`'s built-in store types are `Send + Sync`.
 
@@ -70,7 +70,7 @@ This is only used for LIST operations — presigned URL operations bypass `objec
 
 ### WASM Limitations
 
-- **S3 only**: Azure and GCS builders are gated behind cargo features that are disabled for the Workers runtime
+- **Backend features**: The `multistore-cf-workers` crate supports S3, Azure, and GCS — the `StoreBuilder::Azure` and `StoreBuilder::Gcs` branches work on the Workers runtime, gated behind the `azure` and `gcp` cargo features. Those features are off by default, so the shipped example (`examples/cf-workers`) enables S3 only
 - **`Instant::now()` panics on WASM**: The `UnsignedUrlSigner` avoids the `InstanceCredentialProvider` → `TokenCache` → `Instant::now()` code path that panics on WASM
 - **No `default-members`**: The CF Workers crate is excluded from the workspace default members. Always build with:
   ```bash

--- a/docs/architecture/request-lifecycle.md
+++ b/docs/architecture/request-lifecycle.md
@@ -11,7 +11,6 @@ sequenceDiagram
     participant Gateway as ProxyGateway
     participant Router as Router<br/>(STS, OIDC)
     participant Middleware as Middleware Chain
-    participant Forwarder as Forwarder<br/>(Runtime HTTP Client)
     participant BucketReg as BucketRegistry
     participant CredReg as CredentialRegistry
     participant Backend as Backend Store
@@ -20,7 +19,7 @@ sequenceDiagram
     Runtime->>Gateway: handle_request(req_info, body, collect_body)
     Gateway->>Router: dispatch(req_info)
     alt Router matches (STS, OIDC discovery)
-        Router-->>Gateway: Some(Response)
+        Router-->>Gateway: Some(HandlerAction::Response)
         Gateway-->>Runtime: GatewayResponse::Response
         Runtime-->>Client: Return response
     else No route matches
@@ -40,10 +39,9 @@ sequenceDiagram
         end
 
         alt Forward (GET/HEAD/PUT/DELETE)
-            Gateway->>Forwarder: forward(presigned_url, body)
-            Forwarder->>Backend: Execute presigned URL
-            Backend-->>Forwarder: ForwardResponse (status, headers, body)
-            Forwarder-->>Gateway: ForwardResponse<S>
+            Gateway->>Backend: ProxyBackend::forward(presigned_url, body)
+            Backend->>Backend: Execute presigned URL
+            Backend-->>Gateway: ForwardResponse<ResponseBody> (status, headers, body)
             Note over Middleware: after_dispatch(CompletedRequest)
             Gateway-->>Runtime: GatewayResponse::Forward(ForwardResponse)
             Runtime-->>Client: Stream response body (opaque, zero-copy)
@@ -102,8 +100,8 @@ use multistore_oidc_provider::route_handler::OidcRouterExt;
 use multistore_sts::route_handler::StsRouterExt;
 
 let router = Router::new()
-    .with_oidc_discovery(issuer, signer)
-    .with_sts(sts_creds, jwks_cache, token_key);
+    .with_oidc_discovery(issuer, signers)
+    .with_sts("/.sts", sts_creds, jwks_cache, token_key);
 
 let gateway = ProxyGateway::new(backend, bucket_registry, cred_registry, domain)
     .with_credential_resolver(token_key)
@@ -132,7 +130,7 @@ The gateway takes the resolved bucket config and dispatches it based on the S3 o
 
 Used for: **GET, HEAD, PUT, DELETE**
 
-The handler generates a presigned URL using the backend's `Signer`, then the core calls the runtime-provided `Forwarder` to execute the HTTP request. The `Forwarder` returns a `ForwardResponse<S>` with the backend's status, headers, content length, and an opaque streaming body. The core observes the response metadata (status, content length) and fires `after_dispatch` callbacks on all middleware before returning the response to the runtime. The response body type `S` is an associated type on the `Forwarder` — on CF Workers it's a `web_sys::Response` (zero-copy), on native runtimes it's a `reqwest::Response` or similar.
+The handler generates a presigned URL using the backend's `Signer`, then the core calls the runtime-provided `ProxyBackend::forward` to execute the HTTP request. `forward` returns a `ForwardResponse<ResponseBody>` with the backend's status, headers, content length, and an opaque streaming body. The core observes the response metadata (status, content length) and fires `after_dispatch` callbacks on all middleware before returning the response to the runtime. The response body type is the `ProxyBackend::ResponseBody` associated type (and the request body the `ProxyBackend::Body` associated type) — on CF Workers `ResponseBody` is a `web_sys::Response` (zero-copy), on native runtimes it's a `reqwest::Response` or similar.
 
 - Presigned URL TTL: 300 seconds
 - Headers forwarded: `range`, `if-match`, `if-none-match`, `if-modified-since`, `if-unmodified-since`, `content-type`, `content-length`, `content-md5`, `content-encoding`, `content-disposition`, `cache-control`, `x-amz-content-sha256`
@@ -160,11 +158,11 @@ For lower-level control, `ProxyGateway::handle` returns the raw three-variant `H
 
 All outbound requests to backend object stores include a `User-Agent` header identifying multistore as the caller. This applies to both presigned URL forwards (GET, HEAD, PUT, DELETE) and raw signed requests (multipart operations).
 
-The default value is `multistore/{version}` (e.g. `multistore/0.2.0`). Override it via the gateway builder to include your application name:
+The default value is `multistore/{version}`, where `{version}` is derived from the crate version (`CARGO_PKG_VERSION`) — e.g. `multistore/0.4.0`. Override it via the gateway builder to include your application name:
 
 ```rust
 let gateway = ProxyGateway::new(backend, bucket_registry, cred_registry, domain)
-    .with_user_agent("myapp/1.0 multistore/0.2.0");
+    .with_user_agent("myapp/1.0 multistore/0.4.0");
 ```
 
 This is useful for backend access log analysis and debugging.

--- a/docs/auth/backend-auth.md
+++ b/docs/auth/backend-auth.md
@@ -19,7 +19,10 @@ access_key_id = "AKIAIOSFODNN7EXAMPLE"
 secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 ```
 
-This works for any backend type. For anonymous backend access (e.g., public buckets), omit the credential fields and add `skip_signature = "true"`.
+This works for any backend type. For anonymous backend access (e.g., public buckets), simply omit the `access_key_id` and `secret_access_key` fields — when both are absent, the proxy issues unsigned requests automatically.
+
+> [!NOTE]
+> A `skip_signature` option appears in some examples, but it is currently not honored by the proxy and has no effect. Anonymous access is determined solely by the absence of credentials.
 
 ## OIDC Backend Auth
 
@@ -209,12 +212,12 @@ On subsequent requests, cached credentials are reused until they expire.
 ### Azure Blob Storage
 
 > [!NOTE]
-> **Planned** — Azure OIDC backend auth is planned but not yet implemented. The proxy currently supports Azure with static credentials only.
+> **Partial** — The Azure token-exchange logic exists (behind the `azure` cargo feature), but the end-to-end backend-auth middleware is currently wired up for AWS/S3 buckets only; an `auth_type=oidc` Azure bucket will return a configuration error. For now, use Azure with static credentials.
 
 ### Google Cloud Storage
 
 > [!NOTE]
-> **Planned** — GCS OIDC backend auth is planned but not yet implemented. The proxy currently supports GCS with static credentials only.
+> **Partial** — The GCS token-exchange logic exists (behind the `gcp` cargo feature), but the end-to-end backend-auth middleware is currently wired up for AWS/S3 buckets only; an `auth_type=oidc` GCS bucket will return a configuration error. For now, use GCS with static credentials.
 
 ## Credential Caching
 
@@ -233,5 +236,5 @@ This means the first request to an OIDC-backed bucket incurs a small latency cos
 | **Setup complexity** | Low | Medium (IAM role + OIDC provider registration) |
 | **Credential rotation** | Manual | Automatic (temporary credentials) |
 | **Security** | Long-lived secrets in config | No long-lived secrets |
-| **Cloud providers** | All (S3, Azure, GCS) | AWS S3 (Azure and GCS planned) |
+| **Cloud providers** | All (S3, Azure, GCS) | AWS S3 (Azure/GCS token exchange exists behind cargo features, but middleware wiring is S3-only) |
 | **Latency** | None | Small cost on first request (then cached) |

--- a/docs/auth/proxy-auth.md
+++ b/docs/auth/proxy-auth.md
@@ -86,6 +86,9 @@ When a client calls `AssumeRoleWithWebIdentity`:
 6. If `SESSION_TOKEN_KEY` is configured, the credentials are AES-256-GCM encrypted into the session token (see [Sealed Session Tokens](./sealed-tokens))
 7. The proxy returns the credentials in an XML response matching the AWS STS format
 
+> [!NOTE]
+> The JWKS endpoint is only fetched over `https://` — issuers with any other scheme are rejected to prevent MITM attacks. Time-based claims (`exp`/`nbf`) are validated with a 60-second clock-skew tolerance.
+
 ### STS Request Parameters
 
 | Parameter | Required | Description |
@@ -109,7 +112,7 @@ The response follows the standard AWS STS XML format:
       <Expiration>2024-01-15T01:00:00Z</Expiration>
     </Credentials>
     <AssumedRoleUser>
-      <Arn>github-actions-deployer/alice</Arn>
+      <Arn>github-actions-deployer</Arn>
       <AssumedRoleId>github-actions-deployer</AssumedRoleId>
     </AssumedRoleUser>
   </AssumeRoleWithWebIdentityResult>

--- a/docs/configuration/buckets.md
+++ b/docs/configuration/buckets.md
@@ -27,7 +27,7 @@ secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 | `name` | string | Yes | Client-visible bucket name |
 | `backend_type` | string | Yes | Backend provider: `"s3"`, `"az"`, or `"gcs"` |
 | `backend_prefix` | string | No | Prefix prepended to keys when forwarding to the backend |
-| `anonymous_access` | bool | No | Allow GET/HEAD/LIST without authentication (default: `false`) |
+| `anonymous_access` | bool | Yes | Allow GET/HEAD/LIST without authentication (must be set explicitly; omitting it is a config error) |
 | `allowed_roles` | string[] | No | Role IDs that can be assumed for this bucket |
 | `backend_options` | map | Yes | Provider-specific configuration (see below) |
 
@@ -46,7 +46,7 @@ secret_access_key = "..."
 
 | Option | Required | Description |
 |--------|----------|-------------|
-| `endpoint` | Yes | S3 endpoint URL |
+| `endpoint` | No | S3 endpoint URL; derived from `region` if omitted |
 | `bucket_name` | Yes | Backend bucket name |
 | `region` | Yes | AWS region |
 | `access_key_id` | No | AWS access key (omit for anonymous or OIDC) |

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -50,18 +50,36 @@ The CF Workers runtime uses JSON (as an environment variable or `wrangler.toml` 
 }
 ```
 
+## Top-Level Keys
+
+Alongside the `buckets`, `roles`, and `credentials` arrays, the static file config accepts two optional top-level keys that control the owner identity reported in `ListBuckets` (`ListAllMyBucketsResult`) responses:
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `owner_id` | string | No | Owner ID returned in `ListBuckets` responses. Defaults to `multistore-proxy` when omitted. |
+| `owner_display_name` | string | No | Owner display name returned in `ListBuckets` responses. Defaults to `multistore-proxy` when omitted. |
+
+```toml
+owner_id = "my-org"
+owner_display_name = "My Organization"
+
+[[buckets]]
+name = "public-data"
+# ...
+```
+
 ## Config Providers
 
 The proxy can load configuration from multiple backends. See [Config Providers](./providers/) for details.
 
-| Provider | Feature Flag | Use Case |
-|----------|-------------|----------|
-| [Static File](./providers/static-file) | (always available) | Simple deployments, baked-in config |
-| [HTTP API](./providers/http) | `config-http` | Centralized config service |
-| [DynamoDB](./providers/dynamodb) | `config-dynamodb` | AWS-native infrastructure |
-| [PostgreSQL](./providers/postgres) | `config-postgres` | Database-backed config |
+| Provider | Status | Use Case |
+|----------|--------|----------|
+| [Static File](./providers/static-file) | Built-in (always available) | Simple deployments, baked-in config |
+| [HTTP API](./providers/http) | Planned — not yet implemented | Centralized config service |
+| [DynamoDB](./providers/dynamodb) | Planned — not yet implemented | AWS-native infrastructure |
+| [PostgreSQL](./providers/postgres) | Planned — not yet implemented | Database-backed config |
 
-All providers can be wrapped with a [cache](./providers/cached) for performance.
+The static file provider is the only config provider in the current release. The HTTP, DynamoDB, and PostgreSQL providers are planned features; there are no `config-http`/`config-dynamodb`/`config-postgres` feature flags today.
 
 ## Full Example
 

--- a/docs/configuration/providers/cached.md
+++ b/docs/configuration/providers/cached.md
@@ -1,16 +1,20 @@
 # Caching
 
-Wrap any provider with `CachedProvider` to add in-memory TTL-based caching. This is recommended for all network-backed providers (HTTP, DynamoDB, PostgreSQL).
+`CachedProvider` wraps any inner provider implementing `BucketRegistry` and/or `CredentialRegistry` to add in-memory TTL-based caching. It is useful for network-backed providers where repeated credential/role lookups would otherwise hit the backend.
 
-`CachedProvider` implements both `BucketRegistry` and `CredentialRegistry` when the inner provider does. Credential and role lookups are cached; bucket resolution and listing are delegated directly (since they involve identity-aware authorization).
+> [!NOTE]
+> `CachedProvider` is **example code**, not part of the published library. It is defined in the server example at `examples/server/src/cached.rs` and used within that example's own binary (`multistore_server::cached::CachedProvider`). The `multistore_server` example crate is `publish = false`, so this type is not an importable library API — copy or adapt it for your own deployment.
+
+`CachedProvider` implements `BucketRegistry` when the inner provider does and `CredentialRegistry` when the inner provider does. Credential and role lookups are cached; bucket resolution and listing are delegated directly (since they involve identity-aware authorization).
 
 ## Usage
 
 ```rust
 use multistore_server::cached::CachedProvider;
+use multistore_static_config::StaticProvider;
 use std::time::Duration;
 
-let base = HttpProvider::new("https://config-api.internal".into(), None);
+let base = StaticProvider::from_file("config.toml")?;
 let provider = CachedProvider::new(base, Duration::from_secs(300));
 ```
 
@@ -23,22 +27,12 @@ The first call hits the underlying provider; subsequent calls within the TTL ret
 - **Per-entity caching**: Each role and credential is cached independently
 - **BucketRegistry pass-through**: `get_bucket` and `list_buckets` are always delegated to the inner provider (authorization must not be cached)
 
-## Manual Invalidation
+## Eviction
 
-```rust
-// Invalidate everything
-provider.invalidate_all();
-
-// Invalidate a specific bucket
-provider.invalidate_bucket("my-bucket");
-```
+Eviction is entirely lazy and TTL-based. Each cached credential or role carries an insertion timestamp; on the next lookup after the TTL elapses, the stale entry is ignored and the value is re-fetched from the inner provider (and the cache refreshed). There is no manual-invalidation API — the type implements only `CachedProvider::new(inner, ttl)` plus the two registry traits. To pick up config changes sooner, use a shorter TTL.
 
 ## Recommended TTLs
 
-| Provider | Suggested TTL | Rationale |
-|----------|--------------|-----------|
-| HTTP API | 60–300s | Balance between freshness and API load |
-| DynamoDB | 60–300s | Reduce read capacity costs |
-| PostgreSQL | 30–120s | Reduce query load |
+A shorter TTL means fresher data at the cost of more lookups against the inner provider; a longer TTL reduces backend load at the cost of staleness. Values in the 30–300s range are typical, depending on how quickly config changes need to propagate.
 
 The server example binary uses a 60-second TTL by default when wrapping the static file provider.

--- a/docs/configuration/providers/dynamodb.md
+++ b/docs/configuration/providers/dynamodb.md
@@ -1,14 +1,14 @@
 # DynamoDB Provider
 
-The DynamoDB provider stores configuration in a single DynamoDB table using a PK/SK (partition key / sort key) design pattern.
+::: warning Planned — not yet implemented
+This config provider is a planned feature and does not exist in the current release. The API shown here is a design sketch and is subject to change. The only built-in config provider today is the [static file provider](./static-file.md).
+:::
 
-## Feature Flag
+The DynamoDB provider would store configuration in a single DynamoDB table using a PK/SK (partition key / sort key) design pattern. The sketch below illustrates the intended usage.
 
-```bash
-cargo build -p multistore-server --features multistore/config-dynamodb
-```
+## Usage (design sketch)
 
-## Usage
+The intended constructor would look like:
 
 ```rust
 use multistore::config::dynamodb::DynamoDbProvider;

--- a/docs/configuration/providers/http.md
+++ b/docs/configuration/providers/http.md
@@ -1,14 +1,14 @@
 # HTTP API Provider
 
-The HTTP provider fetches configuration from a centralized REST API. Useful when you have a control plane service that manages proxy configuration.
+::: warning Planned — not yet implemented
+This config provider is a planned feature and does not exist in the current release. The API shown here is a design sketch and is subject to change. The only built-in config provider today is the [static file provider](./static-file.md).
+:::
 
-## Feature Flag
+The HTTP provider would fetch configuration from a centralized REST API — useful when you have a control plane service that manages proxy configuration. The sketch below illustrates the intended shape of the API.
 
-```bash
-cargo build -p multistore-server --features multistore/config-http
-```
+## Usage (design sketch)
 
-## Usage
+The intended constructor would look like:
 
 ```rust
 use multistore::config::http::HttpProvider;
@@ -21,7 +21,7 @@ let provider = HttpProvider::new(
 
 ## Expected API Endpoints
 
-The HTTP provider expects a REST API with these endpoints:
+As designed, the HTTP provider would expect a REST API with these endpoints:
 
 | Endpoint | Method | Returns |
 |----------|--------|---------|

--- a/docs/configuration/providers/index.md
+++ b/docs/configuration/providers/index.md
@@ -9,32 +9,57 @@ The built-in `StaticProvider` implements both traits, loading config from a TOML
 
 ## Registry Traits
 
+The traits are bounded `Clone + MaybeSend + MaybeSync + 'static` (so the same impl works on native multi-threaded runtimes and single-threaded WASM) and use return-position `impl Future` rather than `async fn`:
+
 ```rust
-pub trait BucketRegistry: Clone + Send + Sync + 'static {
-    async fn get_bucket(&self, name: &str, identity: &ResolvedIdentity, operation: &S3Operation)
-        -> Result<ResolvedBucket, ProxyError>;
-    async fn list_buckets(&self, identity: &ResolvedIdentity)
-        -> Result<Vec<BucketEntry>, ProxyError>;
+use std::future::Future;
+
+pub trait BucketRegistry: Clone + MaybeSend + MaybeSync + 'static {
+    fn get_bucket(
+        &self,
+        name: &str,
+        identity: &ResolvedIdentity,
+        operation: &S3Operation,
+    ) -> impl Future<Output = Result<ResolvedBucket, ProxyError>> + MaybeSend;
+
+    fn list_buckets(
+        &self,
+        identity: &ResolvedIdentity,
+    ) -> impl Future<Output = Result<Vec<BucketEntry>, ProxyError>> + MaybeSend;
+
+    /// The owner identity returned in `ListAllMyBucketsResult` responses.
+    /// Provided default returns `("multistore-proxy", "multistore-proxy")`.
+    fn bucket_owner(&self) -> BucketOwner {
+        BucketOwner {
+            id: "multistore-proxy".to_string(),
+            display_name: "multistore-proxy".to_string(),
+        }
+    }
 }
 
-pub trait CredentialRegistry: Clone + Send + Sync + 'static {
-    async fn get_credential(&self, access_key_id: &str)
-        -> Result<Option<StoredCredential>, ProxyError>;
-    async fn get_role(&self, role_id: &str)
-        -> Result<Option<RoleConfig>, ProxyError>;
+pub trait CredentialRegistry: Clone + MaybeSend + MaybeSync + 'static {
+    fn get_credential(
+        &self,
+        access_key_id: &str,
+    ) -> impl Future<Output = Result<Option<StoredCredential>, ProxyError>> + MaybeSend;
+
+    fn get_role(
+        &self,
+        role_id: &str,
+    ) -> impl Future<Output = Result<Option<RoleConfig>, ProxyError>> + MaybeSend;
 }
 ```
 
 ## Available Providers
 
-| Provider | Feature Flag | Best For |
-|----------|-------------|----------|
-| [Static File](./static-file) | (always available) | Simple deployments, single-file config |
-| [HTTP API](./http) | `config-http` | Centralized config service, control planes |
-| [DynamoDB](./dynamodb) | `config-dynamodb` | AWS-native infrastructure |
-| [PostgreSQL](./postgres) | `config-postgres` | Database-backed config |
+| Provider | Status | Best For |
+|----------|--------|----------|
+| [Static File](./static-file) | Built-in (always available) | Simple deployments, single-file config |
+| [HTTP API](./http) | Planned — not yet implemented | Centralized config service, control planes |
+| [DynamoDB](./dynamodb) | Planned — not yet implemented | AWS-native infrastructure |
+| [PostgreSQL](./postgres) | Planned — not yet implemented | Database-backed config |
 
-All providers can be wrapped with [CachedProvider](./cached) for in-memory caching with TTL-based expiration.
+The static file provider is the only built-in config provider in the current release. The HTTP, DynamoDB, and PostgreSQL providers are planned and have no corresponding feature flags yet. Any provider implementing both registry traits can be wrapped with the example [CachedProvider](./cached) for in-memory caching with TTL-based expiration.
 
 ## Implementing Custom Registries
 

--- a/docs/configuration/providers/postgres.md
+++ b/docs/configuration/providers/postgres.md
@@ -1,14 +1,14 @@
 # PostgreSQL Provider
 
-The PostgreSQL provider stores configuration in a PostgreSQL database using sqlx.
+::: warning Planned — not yet implemented
+This config provider is a planned feature and does not exist in the current release. The API shown here is a design sketch and is subject to change. The only built-in config provider today is the [static file provider](./static-file.md).
+:::
 
-## Feature Flag
+The PostgreSQL provider would store configuration in a PostgreSQL database (e.g. via sqlx). The sketch below illustrates the intended usage.
 
-```bash
-cargo build -p multistore-server --features multistore/config-postgres
-```
+## Usage (design sketch)
 
-## Usage
+The intended constructor would look like:
 
 ```rust
 use multistore::config::postgres::PostgresProvider;

--- a/docs/configuration/roles.md
+++ b/docs/configuration/roles.md
@@ -33,10 +33,10 @@ actions = ["get_object", "head_object"]
 |-------|------|----------|-------------|
 | `role_id` | string | Yes | Identifier used as the `RoleArn` in STS requests |
 | `name` | string | Yes | Human-readable display name |
-| `trusted_oidc_issuers` | string[] | Yes | OIDC provider URLs whose tokens are accepted |
+| `trusted_oidc_issuers` | string[] | Validated as required | OIDC provider URLs whose tokens are accepted. Deserializes fine when absent, but config validation rejects a role with no issuers (it could never accept a token). |
 | `required_audience` | string | No | If set, the token's `aud` claim must match |
-| `subject_conditions` | string[] | Yes | Glob patterns matched against the `sub` claim |
-| `max_session_duration_secs` | integer | Yes | Maximum session lifetime (minimum 900s) |
+| `subject_conditions` | string[] | No | Glob patterns matched against the `sub` claim. When omitted or empty, the subject check is skipped entirely and all subjects match. |
+| `max_session_duration_secs` | integer | Yes | Maximum session lifetime granted by this role |
 | `allowed_scopes` | AccessScope[] | Yes | Buckets, prefixes, and actions granted |
 
 ## Trust Policy Evaluation
@@ -47,7 +47,7 @@ When a client calls `AssumeRoleWithWebIdentity`, the proxy evaluates the JWT aga
 2. **Algorithm** — Only RS256 is supported
 3. **Signature** — Verified against the issuer's JWKS (fetched and cached)
 4. **Audience** — If `required_audience` is set, the JWT's `aud` claim must match
-5. **Subject** — The JWT's `sub` claim must match at least one `subject_conditions` pattern
+5. **Subject** — If `subject_conditions` is non-empty, the JWT's `sub` claim must match at least one pattern. If it is empty (or omitted), the subject check is skipped and all subjects pass.
 
 If any check fails, the STS request returns an error.
 
@@ -64,7 +64,11 @@ subject_conditions = [
 ]
 ```
 
-The `sub` claim only needs to match one of the patterns.
+The `sub` claim only needs to match one of the patterns. If `subject_conditions` is omitted or left empty, the subject check is skipped entirely and every subject is accepted.
+
+## Session Duration
+
+`max_session_duration_secs` is the maximum session lifetime this role grants. At mint time, the caller's requested `DurationSeconds` is clamped into the range `[900, max_session_duration_secs]` — the 900-second floor is a clamp applied to the requested session length (matching AWS's STS minimum), not a validated minimum on the field itself. If no duration is requested, 3600s is used (subject to the same clamp).
 
 ## Access Scopes
 

--- a/docs/deployment/cloudflare-workers.md
+++ b/docs/deployment/cloudflare-workers.md
@@ -6,35 +6,55 @@ The CF Workers runtime deploys the proxy to Cloudflare's edge network. It compil
 
 > [!WARNING]
 > - **S3 backends only** — Azure and GCS are not supported on WASM
-> - **Static or API config only** — DynamoDB and Postgres providers require Tokio, which is unavailable
+> - **Static config only** — config is supplied inline via the `PROXY_CONFIG` var
 > - **`SESSION_TOKEN_KEY` required** — Workers are stateless, so sealed tokens are the only way to persist temporary credentials
 
 ## Configuration
 
 ### `wrangler.toml`
 
+The repository ships two Wrangler configs in `examples/cf-workers/`:
+
+- **`wrangler.toml`** — for **local dev only**. Its buckets point at `http://localhost:9000` (the MinIO instance from Docker Compose).
+- **`wrangler.deploy.toml`** — the production config used by CI. Treat this file as the source of truth for the full set of required bindings (rate limiters, Durable Object + migration, bandwidth quotas).
+
+A minimal `PROXY_CONFIG` looks like this (note the TOML table-array form for buckets):
+
 ```toml
-name = "multistore-proxy"
+compatibility_date = "2024-11-11"
 main = "build/worker/shim.mjs"
-compatibility_date = "2024-01-01"
+name = "multistore"
 
 [build]
-command = "cargo install worker-build && worker-build --release"
+# worker-build is pinned to ^0.7 to match the pinned `worker` crate version.
+command = "cargo install worker-build --version '^0.7' && worker-build --release"
 
 [vars]
 VIRTUAL_HOST_DOMAIN = "s3.example.com"
 
 [vars.PROXY_CONFIG]
-buckets = [
-  { name = "public-data", backend_type = "s3", anonymous_access = true, backend_options = { endpoint = "https://s3.us-east-1.amazonaws.com", bucket_name = "my-bucket", region = "us-east-1" } }
-]
-roles = []
-credentials = []
+
+[[vars.PROXY_CONFIG.buckets]]
+name = "public-data"
+backend_type = "s3"
+anonymous_access = true
+allowed_roles = []
+
+[vars.PROXY_CONFIG.buckets.backend_options]
+bucket_name = "my-bucket"
+endpoint = "https://s3.us-east-1.amazonaws.com"
+region = "us-east-1"
 ```
+
+Production deployments also require the rate-limit, Durable Object (with its `[[migrations]]` sqlite class), and bandwidth-quota bindings. Rather than hand-writing these, copy and adapt `examples/cf-workers/wrangler.deploy.toml`, which already includes:
+
+- `[[ratelimits]]` for the `ANON_RATE_LIMITER` and `AUTH_RATE_LIMITER` limiters
+- `[[durable_objects.bindings]]` binding `BANDWIDTH_METER` to the `BandwidthMeter` class, plus the `[[migrations]]` `new_sqlite_classes` entry
+- `[vars.BANDWIDTH_QUOTAS]` per-bucket bandwidth limits
 
 `PROXY_CONFIG` can be either:
 - A JSON string (via `wrangler secret put PROXY_CONFIG`)
-- A JS object (via `[vars.PROXY_CONFIG]` table in `wrangler.toml`, as shown above)
+- A TOML table (via `[vars.PROXY_CONFIG]` in `wrangler.toml`, as shown above)
 
 ### Secrets
 
@@ -80,7 +100,17 @@ This starts a local dev server on port `8787`.
 
 ## Deploying
 
+The default `wrangler.toml` is a **local dev** config — its buckets point at `http://localhost:9000` (MinIO), so it is not suitable for production. Deploy with the production config (`wrangler.deploy.toml`) instead, mirroring how CI deploys (`.github/workflows/deploy.yml`):
+
 ```bash
-cd examples/cf-workers
-npx wrangler deploy
+npx wrangler deploy \
+  --cwd examples/cf-workers \
+  --config wrangler.deploy.toml
+```
+
+Deployment requires the `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` environment variables. After deploying, set the worker secrets:
+
+```bash
+npx wrangler secret put SESSION_TOKEN_KEY --cwd examples/cf-workers --config wrangler.deploy.toml
+npx wrangler secret put OIDC_PROVIDER_KEY --cwd examples/cf-workers --config wrangler.deploy.toml
 ```

--- a/docs/deployment/server.md
+++ b/docs/deployment/server.md
@@ -1,17 +1,17 @@
 # Server Runtime
 
-The server runtime uses Tokio and Hyper to run as a native HTTP server. It supports all backend providers (S3, Azure, GCS) and all config providers.
+The server runtime uses Tokio and Hyper to run as a native HTTP server. It supports the S3 backend by default, with optional Azure and GCS backends behind cargo features.
 
 ## Building
 
 ```bash
-# Default build (S3 + Azure + GCS backends)
+# Default build (S3 backend)
 cargo build --release -p multistore-server
 
-# With additional config providers
+# With Azure and/or GCS backends
 cargo build --release -p multistore-server \
-  --features multistore/config-dynamodb \
-  --features multistore/config-postgres
+  --features multistore/azure \
+  --features multistore/gcp
 ```
 
 The binary is located at `target/release/multistore-server`.
@@ -28,10 +28,9 @@ The binary is located at `target/release/multistore-server`.
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--config` | (required) | Path to the TOML config file |
+| `--config` | `config.toml` | Path to the TOML config file |
 | `--listen` | `0.0.0.0:8080` | Address and port to listen on |
 | `--domain` | (none) | Domain for virtual-hosted-style requests (e.g., `s3.example.com`) |
-| `--sts-config` | (none) | Optional separate TOML file for STS roles/credentials |
 
 ### Environment Variables
 
@@ -50,23 +49,24 @@ export SESSION_TOKEN_KEY=$(openssl rand -base64 32)
 
 ## Docker
 
-```bash
-# Build
-docker build -t multistore-proxy .
+> [!NOTE]
+> The repository does not currently ship a `Dockerfile`. The snippet below is illustrative — you must supply your own image that builds and runs the `multistore-server` binary. Because the binary defaults `--config` to `./config.toml`, pass `--config` explicitly to point at the mounted config path.
 
-# Run
+```bash
+# Run (assuming an image named `multistore-proxy` that you have built)
 docker run \
   -v ./config.toml:/etc/multistore/config.toml \
   -p 8080:8080 \
   -e SESSION_TOKEN_KEY="$SESSION_TOKEN_KEY" \
-  multistore-proxy
+  multistore-proxy \
+  --config /etc/multistore/config.toml
 ```
 
 ## Config Caching
 
-The server binary wraps the config provider with `CachedProvider` (60-second TTL). Config changes from network-backed providers (HTTP, DynamoDB, Postgres) are picked up within 60 seconds without restarting the proxy.
+The server binary wraps the config provider with `CachedProvider` (60-second TTL). With a dynamic, network-backed config provider, changes would be picked up within 60 seconds without restarting the proxy.
 
-For static file configs, changes require a restart.
+The server currently ships only the static file provider, so config changes require a restart.
 
 ## Virtual-Hosted Style
 

--- a/docs/extending/custom-backend.md
+++ b/docs/extending/custom-backend.md
@@ -12,6 +12,20 @@ use object_store::{ObjectStore, signer::Signer};
 use std::sync::Arc;
 
 pub trait ProxyBackend: Clone + MaybeSend + MaybeSync + 'static {
+    /// The streaming body type in forwarded backend responses.
+    type ResponseBody: MaybeSend + 'static;
+
+    /// The request body type accepted by `forward()`.
+    type Body: MaybeSend + 'static;
+
+    /// Execute a presigned ForwardRequest against the backend and return
+    /// the response with a streaming body (GET/HEAD/PUT/DELETE)
+    fn forward(
+        &self,
+        request: ForwardRequest,
+        body: Self::Body,
+    ) -> impl Future<Output = Result<ForwardResponse<Self::ResponseBody>, ProxyError>> + MaybeSend;
+
     /// Create a PaginatedListStore for LIST operations
     fn create_paginated_store(&self, config: &BucketConfig)
         -> Result<Box<dyn PaginatedListStore>, ProxyError>;
@@ -30,7 +44,40 @@ pub trait ProxyBackend: Clone + MaybeSend + MaybeSync + 'static {
 }
 ```
 
-## Three Responsibilities
+## Four Responsibilities
+
+### `forward()`
+
+Executes a presigned `ForwardRequest` against the backend and returns a `ForwardResponse` whose `body` is your runtime's native streaming type (`Self::ResponseBody`). The gateway calls this internally for GET/HEAD/PUT/DELETE; you supply the HTTP transport and the two associated types (`Body` for the inbound request body, `ResponseBody` for the streamed response body):
+
+```rust
+async fn forward(
+    &self,
+    request: ForwardRequest,
+    body: Self::Body,
+) -> Result<ForwardResponse<Self::ResponseBody>, ProxyError> {
+    let response = self.http_client
+        .request(request.method, request.url.as_str())
+        .headers(request.headers)
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| ProxyError::BackendError(e.to_string()))?;
+
+    let status = response.status().as_u16();
+    let headers = response.headers().clone();
+    let content_length = response.content_length();
+
+    Ok(ForwardResponse {
+        status,
+        headers,
+        content_length,
+        body: response.into_body(), // your runtime's streaming body type
+    })
+}
+```
+
+## Other Responsibilities
 
 ### `create_paginated_store()`
 
@@ -103,7 +150,7 @@ use multistore::router::Router;
 use multistore_sts::route_handler::StsRouterExt;
 
 let router = Router::new()
-    .with_sts(sts_creds, jwks_cache, token_key);
+    .with_sts("/.sts", sts_creds, jwks_cache, token_key);
 
 let backend = MyBackend::new(http_client);
 let gateway = ProxyGateway::new(backend, bucket_registry, cred_registry, domain)
@@ -115,9 +162,9 @@ match gateway.handle_request(&req_info, body, |b| to_bytes(b)).await {
     GatewayResponse::Response(result) => {
         // Return the complete response (LIST, errors, STS, etc.)
     }
-    GatewayResponse::Forward(fwd, body) => {
-        // Execute presigned URL with your HTTP client
-        // Stream request body (PUT) or response body (GET)
+    GatewayResponse::Forward(response) => {
+        // Forwarding already happened inside handle_request (via backend.forward);
+        // stream response.body to the client (response.status, response.headers)
     }
 }
 ```

--- a/docs/extending/custom-provider.md
+++ b/docs/extending/custom-provider.md
@@ -9,11 +9,11 @@ use multistore::registry::CredentialRegistry;
 use multistore::error::ProxyError;
 use multistore::types::*;
 
-pub trait CredentialRegistry: Clone + Send + Sync + 'static {
-    async fn get_credential(&self, access_key_id: &str)
-        -> Result<Option<StoredCredential>, ProxyError>;
-    async fn get_role(&self, role_id: &str)
-        -> Result<Option<RoleConfig>, ProxyError>;
+pub trait CredentialRegistry: Clone + MaybeSend + MaybeSync + 'static {
+    fn get_credential(&self, access_key_id: &str)
+        -> impl Future<Output = Result<Option<StoredCredential>, ProxyError>> + MaybeSend;
+    fn get_role(&self, role_id: &str)
+        -> impl Future<Output = Result<Option<RoleConfig>, ProxyError>> + MaybeSend;
 }
 ```
 

--- a/docs/extending/custom-resolver.md
+++ b/docs/extending/custom-resolver.md
@@ -10,18 +10,18 @@ use multistore::api::response::BucketEntry;
 use multistore::error::ProxyError;
 use multistore::types::{BucketOwner, ResolvedIdentity, S3Operation};
 
-pub trait BucketRegistry: Clone + Send + Sync + 'static {
+pub trait BucketRegistry: Clone + MaybeSend + MaybeSync + 'static {
     fn get_bucket(
         &self,
         name: &str,
         identity: &ResolvedIdentity,
         operation: &S3Operation,
-    ) -> impl Future<Output = Result<ResolvedBucket, ProxyError>> + Send;
+    ) -> impl Future<Output = Result<ResolvedBucket, ProxyError>> + MaybeSend;
 
     fn list_buckets(
         &self,
         identity: &ResolvedIdentity,
-    ) -> impl Future<Output = Result<Vec<BucketEntry>, ProxyError>> + Send;
+    ) -> impl Future<Output = Result<Vec<BucketEntry>, ProxyError>> + MaybeSend;
 
     fn bucket_owner(&self) -> BucketOwner { /* default */ }
 }
@@ -103,17 +103,10 @@ let cred_registry = MyCredentialRegistry::new(/* ... */);
 let gateway = ProxyGateway::new(backend, registry, cred_registry, domain);
 
 // In your request handler:
-let req_info = RequestInfo {
-    method: &method,
-    path: &path,
-    query: query.as_deref(),
-    headers: &headers,
-    source_ip: None,
-    params: Default::default(),
-};
+let req_info = RequestInfo::new(&method, &path, query.as_deref(), &headers, None);
 match gateway.handle_request(&req_info, body, |b| to_bytes(b)).await {
     GatewayResponse::Response(result) => { /* return response */ }
-    GatewayResponse::Forward(fwd, body) => { /* execute presigned URL, stream body */ }
+    GatewayResponse::Forward(response) => { /* forwarding already done; stream response.body */ }
 }
 ```
 

--- a/docs/extending/index.md
+++ b/docs/extending/index.md
@@ -6,10 +6,9 @@ The proxy is designed for customization through several trait boundaries. Each c
 |-------|----------|----------------------|
 | [Router / RouteHandler](../architecture/request-lifecycle#router) | Path-based pre-dispatch request interception | `StsRouterExt`, `OidcRouterExt` |
 | [Middleware](../architecture/request-lifecycle#phase-2-proxy-dispatch) | Post-auth dispatch interception and post-dispatch observation | `MeteringMiddleware` (`multistore-metering`) |
-| [Forwarder](../architecture/request-lifecycle#forwardforwardresponses) | Runtime-provided HTTP transport for backend forwarding | `ServerForwarder`, `WorkerForwarder`, `LambdaForwarder` |
 | [BucketRegistry](./custom-resolver) | Bucket lookup, authorization, and listing | `StaticProvider` (static file config) |
 | [CredentialRegistry](./custom-provider) | Credential and role storage | `StaticProvider` (static file config) |
-| [ProxyBackend](./custom-backend) | How the runtime interacts with backends | `ServerBackend`, `WorkerBackend` |
+| [ProxyBackend](./custom-backend) | How the runtime interacts with backends, including the `forward()` method that provides runtime-native HTTP transport for backend forwarding | `ServerBackend`, `WorkerBackend` |
 
 ## When to Customize What
 
@@ -17,7 +16,7 @@ The proxy is designed for customization through several trait boundaries. Each c
 
 **Custom Middleware** — You want to intercept requests after identity resolution (e.g., rate limiting, logging, usage metering). Implement the `Middleware` trait with a `handle` method for pre-dispatch logic and optionally `after_dispatch` for post-response observation. Register via `gateway.with_middleware(my_middleware)`. The `multistore-metering` crate provides `MeteringMiddleware<Q, U>`, which combines a `QuotaChecker` (pre-dispatch quota enforcement) with a `UsageRecorder` (post-dispatch usage tracking). The CF Workers example uses this to enforce per-bucket bandwidth quotas via Durable Objects — see `DoBandwidthMeter` in `examples/cf-workers/src/metering.rs`.
 
-**Custom Forwarder** — You're deploying to a new runtime and need to provide an HTTP client for backend forwarding. Implement the `Forwarder` trait with your runtime's native HTTP client. The response body type is an associated type, allowing zero-copy streaming (e.g., `web_sys::Response` on CF Workers).
+**Custom Forwarding** — You're deploying to a new runtime and need to provide an HTTP client for backend forwarding. Forwarding is not a separate trait: implement the `forward()` method on the `ProxyBackend` trait with your runtime's native HTTP client. The response body type is the `ResponseBody` associated type, allowing zero-copy streaming (e.g., `web_sys::Response` on CF Workers).
 
 **Custom Bucket Registry** — Your namespace mapping needs identity-aware authorization, external API calls for bucket lookup, or a different bucket listing strategy.
 

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -22,35 +22,27 @@ This starts:
 
 ## Run the Proxy
 
-Choose either the native server runtime or Cloudflare Workers:
+The shipped Cloudflare Workers config (`examples/cf-workers/wrangler.toml`) wires the `public-data` and `private-uploads` buckets to the local MinIO instance started above, so it works out of the box:
 
-::: code-group
-
-```bash [Server Runtime]
-cargo run -p multistore-server -- \
-  --config config.local.toml \
-  --listen 0.0.0.0:8080
-```
-
-```bash [Cloudflare Workers]
+```bash
 cd examples/cf-workers && npx wrangler dev
 ```
 
-:::
+The Workers dev server listens on port `8787`.
 
-The server runtime listens on port `8080`. The Workers runtime listens on port `8787`.
+> The native server example (`examples/server/config.toml`) ships a different set of buckets pointed at real AWS S3, not the local MinIO buckets. See [Local Development](./local-development) for details on each runtime's config.
 
 ## Make Your First Request
 
 ```bash
 # Anonymous read from a public bucket
-curl http://localhost:8080/public-data/hello.txt
+curl http://localhost:8787/public-data/hello.txt
 
 # Signed upload with the local dev credential
 AWS_ACCESS_KEY_ID=AKLOCAL0000000000001 \
 AWS_SECRET_ACCESS_KEY="localdev/secret/key/00000000000000000000" \
 aws s3 cp ./myfile.txt s3://private-uploads/myfile.txt \
-    --endpoint-url http://localhost:8080
+    --endpoint-url http://localhost:8787
 ```
 
 ## Next Steps

--- a/docs/getting-started/local-development.md
+++ b/docs/getting-started/local-development.md
@@ -4,7 +4,7 @@ This guide walks through setting up a full local development environment with Mi
 
 ## Docker Compose
 
-The project includes a `docker-compose.yml` that starts MinIO and seeds it with example data:
+The project includes a `docker-compose.yaml` that starts MinIO and seeds it with example data:
 
 ```bash
 docker compose up
@@ -19,25 +19,25 @@ This starts:
 
 The two runtimes use different config formats:
 
-### Server Runtime — `config.local.toml`
+### Workers Runtime — `examples/cf-workers/wrangler.toml`
 
-The server runtime reads a TOML config file. The local development config points buckets at `http://localhost:9000` (MinIO):
-
-```bash
-cargo run -p multistore-server -- \
-  --config config.local.toml \
-  --listen 0.0.0.0:8080
-```
-
-### Workers Runtime — `wrangler.toml`
-
-The CF Workers runtime reads `PROXY_CONFIG` from the Wrangler configuration. It can be a JSON string or a JS object:
+The CF Workers runtime reads `PROXY_CONFIG` from the Wrangler configuration. The shipped `wrangler.toml` points the `public-data` and `private-uploads` buckets at `http://localhost:9000` (the MinIO instance seeded by Docker Compose), so it works against the local backend out of the box:
 
 ```bash
 cd examples/cf-workers && npx wrangler dev
 ```
 
-The Workers dev server runs on port `8787` by default.
+The Workers dev server runs on port `8787` by default. This is the recommended runtime for the local MinIO quickstart.
+
+### Server Runtime — `examples/server/config.toml`
+
+The server runtime reads a TOML config file, defaulting to `config.toml` in the working directory. The shipped `examples/server/config.toml` serves the `harvard-lil` and `cholmes` buckets from real AWS S3 (not the local MinIO buckets), so point `--config` at your own config to use a local backend:
+
+```bash
+cargo run -p multistore-server -- \
+  --config examples/server/config.toml \
+  --listen 0.0.0.0:8080
+```
 
 ## Building
 
@@ -66,23 +66,23 @@ For local development, these are optional but useful:
 
 ## Verifying the Setup
 
-Once the proxy is running, test both anonymous and authenticated access:
+Once the Workers dev server is running, test both anonymous and authenticated access against the local MinIO buckets:
 
 ```bash
 # Anonymous read (should return file contents)
-curl http://localhost:8080/public-data/hello.txt
+curl http://localhost:8787/public-data/hello.txt
 
 # Authenticated upload
 AWS_ACCESS_KEY_ID=AKLOCAL0000000000001 \
 AWS_SECRET_ACCESS_KEY="localdev/secret/key/00000000000000000000" \
 aws s3 cp ./test.txt s3://private-uploads/test.txt \
-    --endpoint-url http://localhost:8080
+    --endpoint-url http://localhost:8787
 
 # List bucket contents
 AWS_ACCESS_KEY_ID=AKLOCAL0000000000001 \
 AWS_SECRET_ACCESS_KEY="localdev/secret/key/00000000000000000000" \
 aws s3 ls s3://private-uploads/ \
-    --endpoint-url http://localhost:8080
+    --endpoint-url http://localhost:8787
 
 # Browse MinIO directly
 open http://localhost:9001

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,7 +46,7 @@ flowchart LR
     subgraph Proxy["multistore-proxy"]
         Auth["Auth<br>(STS, OIDC, SigV4)"]
         Core["Core<br>(Proxy Handler)"]
-        Config["Config<br>(Static, HTTP, DynamoDB, Postgres)"]
+        Config["Config<br>(Static; HTTP/DynamoDB/Postgres planned)"]
     end
 
     Backend["Backend Stores<br>(AWS S3, MinIO, R2, Azure, GCS)"]


### PR DESCRIPTION
## Summary

A pass over the `docs/` site (VitePress) comparing every factual claim against the actual crate code on `main`. The docs had drifted from the implementation in a number of places — including several features that are documented as working but **do not exist in code at all**. This PR corrects them, organized as one commit per docs section.

Each claim below was verified against the source (trait defs, serde structs, CLI args, wrangler/CI config) in this branch.

## Commits

1. **`docs(architecture)`** — Listed all seven workspace crates (the tree was missing `static-config`, `path-mapping`, and the `cf-workers` library crate, and wrongly placed `multistore-cf-workers` under `examples/`). Removed the nonexistent `Forwarder` trait (forwarding is `ProxyBackend::forward`). Fixed the false claim that the registries use plain `Send + Sync`. Clarified CF Workers backend support (the crate supports S3/Azure/GCS via features; only the example is S3-only). Fixed `with_sts`/`with_oidc_discovery` example signatures and the router dispatch return type in the request-lifecycle diagram. Bumped stale `0.2.0` version literals to `0.4.0`.

2. **`docs(configuration)`** — Marked the **HTTP / DynamoDB / PostgreSQL config providers** as *Planned — not yet implemented* (no types, no `config-*` cargo features, no `sqlx`/`aws_sdk_dynamodb` deps exist; `StaticProvider` is the only built-in provider). Corrected the registry trait definitions to the real `MaybeSend + MaybeSync` + RPITIT form and added the omitted `bucket_owner`. Fixed field optionality: `anonymous_access` is required, S3 `endpoint` is optional, `subject_conditions` is optional/empty=match-all, and the 900s session floor is a mint-time clamp (not a field minimum). Documented `CachedProvider` as example code (not an importable library) and removed its fictional `invalidate_all`/`invalidate_bucket` API. Documented the previously-undocumented `owner_id`/`owner_display_name` keys.

3. **`docs(auth)`** — Anonymous backend access is achieved by **omitting** `access_key_id`/`secret_access_key`; the documented `skip_signature = "true"` is a no-op (never read by any code) and was removed. Reframed Azure/GCS backend auth as *partial* (token-exchange logic exists behind the `azure`/`gcp` features, but middleware wiring is AWS/S3-only). Corrected the STS response `<Arn>` example (it's the bare role_id, the subject is not appended). Noted JWKS https-only enforcement and the 60s clock-skew tolerance.

4. **`docs(deployment)`** — Removed references to the nonexistent `config.local.toml`; based the local quickstart on the cf-workers runtime whose `wrangler.toml` wires the MinIO buckets seeded by `docker-compose` (port 8787). Fixed `docker-compose.yml` → `docker-compose.yaml`. Dropped the nonexistent `--features multistore/config-dynamodb|config-postgres` and `--sts-config` flag, and marked the Docker section illustrative (no `Dockerfile` ships). Synced the `wrangler.toml` example with the real file and pointed real deploys at `wrangler.deploy.toml` with its required bindings, matching `.github/workflows/deploy.yml`.

5. **`docs(extending)`** — Fixed the copy-paste code snippets so they compile: added the required `ResponseBody`/`Body` associated types and `forward()` to the `ProxyBackend` snippet; corrected `GatewayResponse::Forward` to its real single-field shape; fixed the registry trait definitions (`MaybeSend + MaybeSync` + RPITIT); replaced the incomplete `RequestInfo { .. }` literal with `RequestInfo::new(..)`; fixed `with_sts` arity; removed the standalone `Forwarder` extension point.

## Decisions for reviewers

- **Planned providers:** For the HTTP/DynamoDB/PostgreSQL config providers I **kept the pages** but added a prominent `::: warning Planned — not yet implemented` callout and removed any "this works today / enable this feature flag" wording, rather than deleting them — this preserves the roadmap intent and keeps the docs nav valid. If you'd rather drop these pages entirely, say so and I'll remove them and their nav entries.
- **Quickstart runtime:** The getting-started quickstart now targets the **Workers runtime on port 8787**, because that's the only shipped config (`examples/cf-workers/wrangler.toml`) that actually serves the `public-data`/`private-uploads` MinIO buckets seeded by `docker-compose`. The server example serves different AWS-backed buckets, which is now noted explicitly.

## Verification

Content-only markdown edits — no changes to `config.ts`, nav, or files. Code signatures cited above were checked against the source in this branch; callout/code-fence balance was linted. The VitePress build runs in CI (`docs.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
