### PR TITLE
ci: per-PR docs previews + skip redundant worker/docs deploys

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,0 +1,110 @@
+name: Docs Preview
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    paths:
+      - "docs/**"
+      - ".github/workflows/docs-preview.yml"
+
+concurrency:
+  group: docs-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Build & Deploy
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    environment: preview
+    defaults:
+      run:
+        working-directory: docs
+    outputs:
+      deploy_url: ${{ steps.url.outputs.deploy_url }}
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+        with:
+          version: 10
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: docs/pnpm-lock.yaml
+
+      - run: pnpm install --frozen-lockfile
+
+      # No VITEPRESS_BASE: previews are served at the root of a workers.dev
+      # subdomain, unlike production which lives under /multistore/ on Pages.
+      - run: pnpm docs:build
+
+      - name: Deploy preview to Cloudflare Workers
+        run: |
+          npx wrangler deploy \
+            --config wrangler.preview.toml \
+            --name "multistore-docs-pr-${{ github.event.pull_request.number }}"
+
+      - name: Get deploy URL
+        id: url
+        run: |
+          URL="https://multistore-docs-pr-${{ github.event.pull_request.number }}.${{ vars.CLOUDFLARE_WORKERS_SUBDOMAIN }}.workers.dev"
+          echo "deploy_url=$URL" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for deployment to be live
+        run: |
+          URL="${{ steps.url.outputs.deploy_url }}"
+          for i in $(seq 1 30); do
+            if curl -sf -o /dev/null "$URL" 2>/dev/null; then
+              echo "Docs preview is live"
+              exit 0
+            fi
+            echo "Attempt $i: waiting for docs preview..."
+            sleep 2
+          done
+          echo "Docs preview did not become live in time"
+          exit 1
+
+  comment:
+    name: PR Comment
+    needs: deploy
+    if: github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Find Comment
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: Docs preview deployed to
+
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            📖 Docs preview deployed to ${{ needs.deploy.outputs.deploy_url }}
+
+            * Date: `${{ github.event.pull_request.updated_at }}`
+            * Commit: ${{ github.sha }}
+          edit-mode: replace
+
+  cleanup:
+    name: Cleanup Preview
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+    steps:
+      - name: Delete docs preview worker
+        run: npx wrangler delete --name "multistore-docs-pr-${{ github.event.pull_request.number }}" --force

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -3,6 +3,10 @@ name: Preview
 on:
   pull_request:
     types: [opened, synchronize, reopened, closed]
+    # Skip the worker preview when a PR only touches docs (see docs-preview.yml).
+    # The worker still deploys whenever any non-docs file changes.
+    paths-ignore:
+      - "docs/**"
 
 concurrency:
   group: preview-${{ github.event.pull_request.number }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -3,6 +3,10 @@ name: Staging
 on:
   push:
     branches: [main]
+    # Docs-only pushes deploy to GitHub Pages via docs.yml; no need to
+    # redeploy the staging worker for them.
+    paths-ignore:
+      - "docs/**"
 
 concurrency:
   group: staging

--- a/docs/wrangler.preview.toml
+++ b/docs/wrangler.preview.toml
@@ -1,0 +1,14 @@
+# Cloudflare Workers static-assets config for per-PR documentation previews.
+#
+# The built VitePress site (docs/.vitepress/dist) is served as static assets on
+# a workers.dev subdomain. This is an assets-only Worker (no `main` script). The
+# per-PR worker name is supplied at deploy time via `--name`, e.g.
+# `multistore-docs-pr-123`, so each PR gets its own isolated preview URL.
+#
+# Production docs continue to deploy to GitHub Pages via docs.yml; this config is
+# only used for ephemeral PR previews.
+name = "multistore-docs"
+compatibility_date = "2024-11-11"
+
+[assets]
+directory = ".vitepress/dist"


### PR DESCRIPTION
## Summary

Two CI improvements, one commit each:

1. **Per-PR documentation previews** — every PR that touches `docs/**` gets a live, isolated preview of the rendered VitePress site, with the URL posted as a PR comment.
2. **Skip redundant worker deploys** — the Cloudflare worker no longer redeploys when a change only touches docs (and docs builds already don't run for code-only changes), so the two pipelines stay independent.

## How docs previews work

A new `docs-preview.yml` builds the VitePress site and deploys it as an **assets-only Cloudflare Worker** at `https://multistore-docs-pr-<N>.<subdomain>.workers.dev`, then:
- comments the preview URL on the PR (updating the same comment on each push), and
- deletes the preview worker when the PR is closed.

This deliberately mirrors the existing **worker** preview pattern in `preview.yml` (same `peter-evans` comment actions, same concurrency/cleanup shape) and **reuses the existing `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_WORKERS_SUBDOMAIN`** — so it needs **no new infrastructure, project, or token scopes**. Previews are served at the subdomain root (no `VITEPRESS_BASE`), while production docs continue to publish to GitHub Pages under `/multistore/` via the unchanged `docs.yml`.

A small `docs/wrangler.preview.toml` declares the assets-only worker (`[assets] directory = ".vitepress/dist"`); the per-PR name is supplied at deploy time via `--name`.

## Pipeline efficiency

| Change set | Worker (`preview`/`staging`) | Docs (`docs-preview`/`docs`) |
|---|---|---|
| Docs only | **skipped** (new) | runs |
| Code only | runs | skipped (already true) |
| Both | runs | runs |

Implemented by adding `paths-ignore: docs/**` to `preview.yml` (PRs) and `staging.yml` (push to main). The reverse direction already held: `docs.yml` is gated on `paths: docs/**`, and the new `docs-preview.yml` is gated the same way.

## Notes / decisions for reviewers

- **Why Workers static assets instead of Cloudflare Pages?** Pages is the other natural choice, but it would require creating a Pages project and granting the API token Pages scope. The assets-Worker route reuses the exact credentials/subdomain the worker previews already use, so it works out of the box. Happy to switch to Pages if you'd prefer the deployment-history/alias features it offers.
- **`environment: preview`** is set on the docs deploy job to resolve `vars.CLOUDFLARE_WORKERS_SUBDOMAIN` and secrets identically to the proven worker-preview job. If the `preview` environment has required reviewers, docs previews will wait for approval just like worker previews do today.
- The PR comment uses a distinct marker ("Docs preview deployed to…") so it never clobbers the worker preview's comment.
- **Out of scope (optional follow-up):** `ci.yml` (fmt/clippy/test/integration) still runs on docs-only pushes. I left it untouched to avoid interfering with required status checks, but it could be path-filtered too if desired.

## Verification

- All four affected/added workflows parse as valid YAML.
- The preview build reuses the same `pnpm docs:build` already run in production by `docs.yml`, and the wrangler `directory` (`.vitepress/dist`) matches the exact artifact path `docs.yml` publishes. End-to-end behavior (Cloudflare deploy, comment, cleanup) will exercise on this PR itself once CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
