### PR TITLE
ci(smoke): default FEDERATION_TEST_KEY when repo var is empty

### DIFF
--- a/tests/smoke/test_federation.py
+++ b/tests/smoke/test_federation.py
@@ -31,7 +31,10 @@ import requests
 
 DEPLOY_URL = os.environ.get("DEPLOY_URL", "http://localhost:8787").rstrip("/")
 FEDERATION_BUCKET = "federated-test"
-FEDERATION_TEST_KEY = os.environ.get("FEDERATION_TEST_KEY", "hello.txt")
+# Use `or` (not a get() default): the workflow passes `${{ vars.FEDERATION_TEST_KEY }}`,
+# which expands to "" — not unset — when the repo var is missing, and an empty key
+# would GET the bucket root instead of the object.
+FEDERATION_TEST_KEY = os.environ.get("FEDERATION_TEST_KEY") or "hello.txt"
 
 
 def test_federation_serves_private_object():


### PR DESCRIPTION
## Problem

The staging smoke run failed only on `test_federation.py`, hitting `/federated-test/` with **no object key**.

`deploy.yml` passes `FEDERATION_TEST_KEY: ${{ vars.FEDERATION_TEST_KEY }}`, which expands to an **empty string** (not unset) when the repo variable is missing. The test used `os.environ.get("FEDERATION_TEST_KEY", "hello.txt")`, whose default only applies when the var is *absent* — so the empty value slipped through and the GET went to the bucket root instead of the object.

## Fix

```python
FEDERATION_TEST_KEY = os.environ.get("FEDERATION_TEST_KEY") or "hello.txt"
```

Note: this only fixes the wrong-path bug. The federation smoke test will still be red until the one-time AWS setup is done (IAM OIDC provider for `STAGING_OIDC_ISSUER`, trusting role, real role ARN + bucket in `wrangler.deploy.toml`, and the test object seeded in the private bucket).

🤖 Generated with [Claude Code](https://claude.com/claude-code)