### PR TITLE
fix(oidc-provider): surface federation failures as actionable errors, not opaque 500s

### DIFF
--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -45,6 +45,17 @@ pub enum ProxyError {
     #[error("backend error: {0}")]
     BackendError(String),
 
+    /// The proxy could not obtain credentials from the backend cloud's identity
+    /// broker — e.g. AWS STS rejected the proxy's federated identity
+    /// (`InvalidIdentityToken`), or the broker was unreachable. Kept distinct
+    /// from [`Internal`](Self::Internal) so a federation/trust misconfiguration
+    /// surfaces as a diagnosable `502` rather than an opaque `500`. Carries the
+    /// provider error *code* only (safe to expose); the full provider message —
+    /// which may contain role ARNs / account IDs — is logged at the conversion
+    /// site, not returned to the caller.
+    #[error("backend authentication failed: {0}")]
+    BackendAuthError(String),
+
     /// A conditional request header (e.g. `If-Match`) was not satisfied.
     #[error("precondition failed")]
     PreconditionFailed,
@@ -76,6 +87,7 @@ impl ProxyError {
             Self::InvalidOidcToken(_) => "InvalidIdentityToken",
             Self::RoleNotFound(_) => "AccessDenied",
             Self::BackendError(_) => "ServiceUnavailable",
+            Self::BackendAuthError(_) => "BackendAuthenticationFailed",
             Self::PreconditionFailed => "PreconditionFailed",
             Self::NotModified => "NotModified",
             Self::ConfigError(_) => "InternalError",
@@ -95,6 +107,7 @@ impl ProxyError {
             Self::PreconditionFailed => 412,
             Self::NotModified => 304,
             Self::BackendError(_) => 503,
+            Self::BackendAuthError(_) => 502,
             Self::ConfigError(_) | Self::Internal(_) => 500,
         }
     }
@@ -109,6 +122,11 @@ impl ProxyError {
         match self {
             Self::BackendError(_) => "Service unavailable".to_string(),
             Self::ConfigError(_) | Self::Internal(_) => "Internal server error".to_string(),
+            // Safe to surface: holds only the provider error code (e.g.
+            // `InvalidIdentityToken`), never the raw provider message.
+            Self::BackendAuthError(code) => {
+                format!("Failed to obtain backend credentials: {code}")
+            }
             other => other.to_string(),
         }
     }
@@ -121,5 +139,30 @@ impl ProxyError {
             object_store::Error::NotModified { .. } => Self::NotModified,
             _ => Self::BackendError(e.to_string()),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn backend_auth_error_is_502_and_not_opaque() {
+        let err = ProxyError::BackendAuthError("InvalidIdentityToken".into());
+        assert_eq!(err.status_code(), 502);
+        assert_eq!(err.s3_error_code(), "BackendAuthenticationFailed");
+        // Distinct from the generic internal-error message, and surfaces the
+        // provider code so the failure is diagnosable from the response alone.
+        let msg = err.safe_message();
+        assert_ne!(msg, "Internal server error");
+        assert!(msg.contains("InvalidIdentityToken"), "got: {msg}");
+    }
+
+    #[test]
+    fn internal_error_stays_opaque_5xx() {
+        // Genuine internal errors keep the generic message (no detail leak).
+        let err = ProxyError::Internal("secret backend detail".into());
+        assert_eq!(err.status_code(), 500);
+        assert_eq!(err.safe_message(), "Internal server error");
     }
 }

--- a/crates/oidc-provider/src/lib.rs
+++ b/crates/oidc-provider/src/lib.rs
@@ -175,7 +175,51 @@ impl From<multistore_backend_federation::FederationError> for OidcProviderError 
 
 impl From<OidcProviderError> for multistore::error::ProxyError {
     fn from(e: OidcProviderError) -> Self {
-        multistore::error::ProxyError::Internal(e.to_string())
+        use multistore::error::ProxyError;
+
+        // Federation failures must not collapse into an opaque 500. Map each
+        // cause to a status that reflects whose problem it is, and log the full
+        // (possibly ARN-bearing) detail here — it is the only place the raw
+        // provider message is still available, and it must not reach the caller.
+        match e {
+            OidcProviderError::StsError { code, message } => {
+                tracing::error!(
+                    sts_code = %code,
+                    sts_message = %message,
+                    "backend STS rejected the federation exchange"
+                );
+                match code.as_str() {
+                    // The role's trust policy / permissions deny the proxy
+                    // identity: the object genuinely cannot be served → 403.
+                    "AccessDenied" => ProxyError::AccessDenied,
+                    // Our minted assertion was rejected (bad key, issuer, or no
+                    // registered provider), or any other STS error → 502: the
+                    // gateway failed to authenticate to its upstream broker.
+                    _ => ProxyError::BackendAuthError(code),
+                }
+            }
+            // Local signing-key problems: the deploy's OIDC_PROVIDER_KEY is
+            // missing/malformed. The gateway can't mint an assertion, so it
+            // can't federate → 502 (not a generic 500), with the cause logged.
+            OidcProviderError::KeyError(detail) => {
+                tracing::error!(error = %detail, "OIDC provider RSA key error");
+                ProxyError::BackendAuthError("ProviderKeyError".into())
+            }
+            OidcProviderError::SigningError(detail) => {
+                tracing::error!(error = %detail, "OIDC provider JWT signing error");
+                ProxyError::BackendAuthError("SigningError".into())
+            }
+            // Couldn't reach the broker or parse its reply: transient/upstream
+            // → 503 (retryable), distinct from a permanent auth rejection.
+            OidcProviderError::HttpError(detail) => {
+                tracing::error!(error = %detail, "backend STS transport error");
+                ProxyError::BackendError(detail)
+            }
+            OidcProviderError::ExchangeError(detail) => {
+                tracing::error!(error = %detail, "backend credential exchange failed");
+                ProxyError::BackendError(detail)
+            }
+        }
     }
 }
 
@@ -342,10 +386,59 @@ mod tests {
     }
 
     #[test]
-    fn error_converts_to_proxy_error() {
-        let err = OidcProviderError::ExchangeError("test".into());
-        let proxy_err: multistore::error::ProxyError = err.into();
-        assert!(proxy_err.to_string().contains("test"));
-        assert_eq!(proxy_err.status_code(), 500);
+    fn exchange_error_maps_to_retryable_503() {
+        // Transport / unparseable-response failures are upstream and retryable.
+        let proxy_err: multistore::error::ProxyError =
+            OidcProviderError::ExchangeError("boom".into()).into();
+        assert_eq!(proxy_err.status_code(), 503);
+        assert!(proxy_err.to_string().contains("boom"));
+    }
+
+    #[test]
+    fn http_error_maps_to_retryable_503() {
+        let proxy_err: multistore::error::ProxyError =
+            OidcProviderError::HttpError("connreset".into()).into();
+        assert_eq!(proxy_err.status_code(), 503);
+    }
+
+    #[test]
+    fn sts_rejection_maps_to_502_not_500() {
+        // The headline regression: a rejected federation assertion must surface
+        // as a diagnosable 502, never an opaque 500 InternalError.
+        let proxy_err: multistore::error::ProxyError = OidcProviderError::StsError {
+            code: "InvalidIdentityToken".into(),
+            message: "No OpenIDConnect provider found in your account".into(),
+        }
+        .into();
+        assert_eq!(proxy_err.status_code(), 502);
+        assert_eq!(proxy_err.s3_error_code(), "BackendAuthenticationFailed");
+        // The provider *code* is surfaced; the raw message is not.
+        let safe = proxy_err.safe_message();
+        assert!(safe.contains("InvalidIdentityToken"), "got: {safe}");
+        assert!(!safe.contains("your account"), "raw STS message leaked: {safe}");
+    }
+
+    #[test]
+    fn sts_access_denied_maps_to_403() {
+        // A trust-policy/permissions denial is a real authorization result.
+        let proxy_err: multistore::error::ProxyError = OidcProviderError::StsError {
+            code: "AccessDenied".into(),
+            message: "not authorized to perform sts:AssumeRoleWithWebIdentity".into(),
+        }
+        .into();
+        assert_eq!(proxy_err.status_code(), 403);
+        assert_eq!(proxy_err.s3_error_code(), "AccessDenied");
+    }
+
+    #[test]
+    fn key_and_signing_errors_map_to_502_not_500() {
+        // A bad OIDC_PROVIDER_KEY means we can't mint an assertion → 502, logged.
+        let key_err: multistore::error::ProxyError =
+            OidcProviderError::KeyError("bad pem".into()).into();
+        assert_eq!(key_err.status_code(), 502);
+
+        let sign_err: multistore::error::ProxyError =
+            OidcProviderError::SigningError("rsa failure".into()).into();
+        assert_eq!(sign_err.status_code(), 502);
     }
 }

--- a/crates/oidc-provider/src/lib.rs
+++ b/crates/oidc-provider/src/lib.rs
@@ -415,7 +415,10 @@ mod tests {
         // The provider *code* is surfaced; the raw message is not.
         let safe = proxy_err.safe_message();
         assert!(safe.contains("InvalidIdentityToken"), "got: {safe}");
-        assert!(!safe.contains("your account"), "raw STS message leaked: {safe}");
+        assert!(
+            !safe.contains("your account"),
+            "raw STS message leaked: {safe}"
+        );
     }
 
     #[test]

--- a/docs/deployment/cloudflare-workers.md
+++ b/docs/deployment/cloudflare-workers.md
@@ -58,11 +58,32 @@ Production deployments also require the rate-limit, Durable Object (with its `[[
 
 ### Secrets
 
-Set sensitive values as secrets:
+The two secrets have **different formats** — generate each with the right tool:
 
 ```bash
-wrangler secret put SESSION_TOKEN_KEY
-wrangler secret put OIDC_PROVIDER_KEY
+# SESSION_TOKEN_KEY — base64 of 32 random bytes (AES-256-GCM sealing key)
+openssl rand -base64 32 | wrangler secret put SESSION_TOKEN_KEY
+
+# OIDC_PROVIDER_KEY — PKCS#8 PEM RSA private key (used to sign JWTs and derive the published JWKS)
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 | wrangler secret put OIDC_PROVIDER_KEY
+```
+
+> [!IMPORTANT]
+> `OIDC_PROVIDER_KEY` must be a **PKCS#8** PEM RSA private key (`-----BEGIN PRIVATE KEY-----`).
+> Use `openssl genpkey`, **not** `openssl genrsa` (which emits PKCS#1, `-----BEGIN RSA PRIVATE KEY-----`,
+> and is rejected by `RsaPrivateKey::from_pkcs8_pem`). A random/symmetric value such as
+> `openssl rand -base64 32` will fail to parse, and the OIDC provider will fail to initialize —
+> the worker then returns HTTP 500 on **every** request (deploys never become live).
+> Convert an existing PKCS#1 key with `openssl pkcs8 -topk8 -nocrypt -in pkcs1.pem`.
+
+When deploying via GitHub Actions, these are environment-scoped secrets. Previews reuse the staging
+OIDC issuer (so AWS validates against staging's published JWKS), so `OIDC_PROVIDER_KEY` **must be the
+same value in the `preview` and `staging` environments** — generate it once and set it in both:
+
+```bash
+OIDC_KEY="$(openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048)"
+printf '%s' "$OIDC_KEY" | gh secret set OIDC_PROVIDER_KEY --env staging --repo <owner>/<repo>
+printf '%s' "$OIDC_KEY" | gh secret set OIDC_PROVIDER_KEY --env preview --repo <owner>/<repo>
 ```
 
 ### Environment Variables


### PR DESCRIPTION
## Problem

Every backend-federation failure collapsed into `ProxyError::Internal`, so the proxy returned a generic **`500 InternalError` / "Internal server error"** regardless of cause, with the real reason discarded — both from the response *and* from logs. We hit this repeatedly while debugging the `federated-test` smoke test: a key/issuer mismatch (AWS STS `InvalidIdentityToken`) was indistinguishable from an actual proxy crash.

Root cause (`crates/oidc-provider/src/lib.rs`):

```rust
impl From<OidcProviderError> for ProxyError {
    fn from(e: OidcProviderError) -> Self {
        ProxyError::Internal(e.to_string())   // every variant -> 500, detail dropped
    }
}
```

## Change

Map each federation failure to a status that reflects whose problem it is, and **log the full (possibly ARN-bearing) provider detail** at the conversion site — the last place it's available and somewhere it must not reach the caller:

| Cause | Before | After |
|---|---|---|
| STS rejection (`InvalidIdentityToken`, …) | 500 `InternalError` | **502 `BackendAuthenticationFailed`** |
| STS `AccessDenied` (trust policy / perms) | 500 `InternalError` | **403 `AccessDenied`** |
| Bad `OIDC_PROVIDER_KEY` / signing failure | 500 `InternalError` | **502** (cause logged) |
| Broker unreachable / unparseable reply | 500 `InternalError` | **503 `ServiceUnavailable`** |

Adds `ProxyError::BackendAuthError`, which carries the provider error **code only** (e.g. `InvalidIdentityToken`) — safe to surface; the raw message is logged via `tracing::error!`, never returned. With the worker's console subscriber, `wrangler tail` now shows the actual STS code + message instead of nothing.

## Tests

Unit tests for every mapping (`crates/oidc-provider/src/lib.rs`, `crates/core/src/error.rs`): each asserts the expected status, that it is **not** an opaque 500, and that the raw provider message does not leak into `safe_message()`.

Verified locally with the CI command set: `cargo check`, `cargo clippy -- -D warnings`, `cargo test`, and `cargo check -p multistore-cf-workers --target wasm32-unknown-unknown` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)