### PR TITLE
docs(backend-auth): correct the skip_signature callout — it IS honored

### DIFF
--- a/docs/auth/backend-auth.md
+++ b/docs/auth/backend-auth.md
@@ -19,10 +19,18 @@ access_key_id = "AKIAIOSFODNN7EXAMPLE"
 secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 ```
 
-This works for any backend type. For anonymous backend access (e.g., public buckets), simply omit the `access_key_id` and `secret_access_key` fields — when both are absent, the proxy issues unsigned requests automatically.
+This works for any backend type. For **anonymous** backend access (e.g., public buckets), omit `access_key_id`/`secret_access_key` and set `skip_signature = "true"`:
+
+```toml
+[buckets.backend_options]
+endpoint = "https://s3.us-east-1.amazonaws.com"
+bucket_name = "my-public-bucket"
+region = "us-east-1"
+skip_signature = "true"
+```
 
 > [!NOTE]
-> A `skip_signature` option appears in some examples, but it is currently not honored by the proxy and has no effect. Anonymous access is determined solely by the absence of credentials.
+> `skip_signature` **is** honored: the proxy passes every `backend_options` entry through to `object_store` (`create_builder` in `multistore`'s `backend` module), and `object_store` then skips SigV4 and issues unsigned requests. It is **required** for public-bucket access — omitting credentials *without* it does not yield anonymous access: `object_store` falls back to its default credential chain (instance metadata, environment, etc.) and still attempts to sign. For `auth_type = oidc` backends, the federated-credential injection clears `skip_signature` so the proxy signs with the temporary credentials it obtains.
 
 ## OIDC Backend Auth
 


### PR DESCRIPTION
## Problem

`docs/auth/backend-auth.md` documented backend signing backwards. The "Static Backend Credentials" section claimed:

1. Omitting `access_key_id`/`secret_access_key` makes the proxy "issue unsigned requests automatically."
2. (NOTE) `skip_signature` "is currently not honored by the proxy and has no effect."

Both are wrong, and they contradicted `docs/configuration/buckets.md`, which already documents `skip_signature = "true"` for unsigned/anonymous access.

## What's actually true (verified against object_store 0.13.1)

- `create_builder` (`crates/core/src/backend/mod.rs:175`) applies **every** parseable option: `if let Ok(key) = k.parse() { b = b.with_config(key, v) }`.
- object_store parses `skip_signature` → `AmazonS3ConfigKey::SkipSignature` (`builder.rs:497`) and applies it (`:646`); when set, `AmazonS3` skips SigV4 and issues unsigned requests (`with_skip_signature`, `:907`).
- With **no** static creds and `skip_signature` unset, object_store's `build()` falls back to the `InstanceCredentialProvider` (`builder.rs:1034+`) and signs — it does **not** go anonymous.

So `skip_signature = "true"` is the actual control for public-bucket access, and it's used by `examples/server/config.toml` and the cf-workers wrangler examples. The OIDC backend-auth path even clears `skip_signature` in `FederatedCredentials::apply_to` specifically to re-enable signing.

## Change

Rewrites the section: anonymous access needs `skip_signature = "true"` (with an example), and the NOTE now states it is honored and required, with the correct fallback when it's absent. Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
