### PR TITLE
feat(oidc-provider): make OidcCredentialProvider cheaply cloneable (shareable warm cache)

### DIFF
--- a/crates/oidc-provider/src/cache.rs
+++ b/crates/oidc-provider/src/cache.rs
@@ -16,21 +16,22 @@ use crate::BackendCredentials;
 const EXPIRY_MARGIN_SECS: i64 = 60;
 
 /// Thread-safe TTL cache for cloud credentials.
+///
+/// `Clone` shares the same underlying store (the entries map is behind an
+/// `Arc`), so a cloned [`OidcCredentialProvider`](crate::OidcCredentialProvider)
+/// keeps hitting the same cache — letting a runtime hold the provider in a
+/// shared/`static` slot and reuse it across requests instead of re-minting and
+/// re-exchanging every time.
+#[derive(Clone, Default)]
 pub struct CredentialCache {
-    entries: Mutex<HashMap<String, Arc<BackendCredentials>>>,
-}
-
-impl Default for CredentialCache {
-    fn default() -> Self {
-        Self::new()
-    }
+    entries: Arc<Mutex<HashMap<String, Arc<BackendCredentials>>>>,
 }
 
 impl CredentialCache {
     /// Create an empty credential cache.
     pub fn new() -> Self {
         Self {
-            entries: Mutex::new(HashMap::new()),
+            entries: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 

--- a/crates/oidc-provider/src/exchange/aws.rs
+++ b/crates/oidc-provider/src/exchange/aws.rs
@@ -83,11 +83,7 @@ impl AwsExchange {
 }
 
 impl<H: HttpExchange> CredentialExchange<H> for AwsExchange {
-    async fn exchange(
-        &self,
-        http: &H,
-        jwt: &str,
-    ) -> Result<BackendCredentials, OidcProviderError> {
+    async fn exchange(&self, http: &H, jwt: &str) -> Result<BackendCredentials, OidcProviderError> {
         // Build the request with this module's `AssumeRoleWithWebIdentity`, hand
         // its (unencoded) pairs to the runtime's HTTP client — which
         // form-urlencodes them — then parse the reply.

--- a/crates/oidc-provider/src/exchange/azure.rs
+++ b/crates/oidc-provider/src/exchange/azure.rs
@@ -49,11 +49,7 @@ impl AzureExchange {
 }
 
 impl<H: HttpExchange> CredentialExchange<H> for AzureExchange {
-    async fn exchange(
-        &self,
-        http: &H,
-        jwt: &str,
-    ) -> Result<BackendCredentials, OidcProviderError> {
+    async fn exchange(&self, http: &H, jwt: &str) -> Result<BackendCredentials, OidcProviderError> {
         let form = [
             ("grant_type", "client_credentials"),
             (

--- a/crates/oidc-provider/src/exchange/gcp.rs
+++ b/crates/oidc-provider/src/exchange/gcp.rs
@@ -51,11 +51,7 @@ impl GcpExchange {
 }
 
 impl<H: HttpExchange> CredentialExchange<H> for GcpExchange {
-    async fn exchange(
-        &self,
-        http: &H,
-        jwt: &str,
-    ) -> Result<BackendCredentials, OidcProviderError> {
+    async fn exchange(&self, http: &H, jwt: &str) -> Result<BackendCredentials, OidcProviderError> {
         // Step 1: Exchange JWT for federated access token via GCP STS
         let sts_form = [
             (

--- a/crates/oidc-provider/src/lib.rs
+++ b/crates/oidc-provider/src/lib.rs
@@ -56,6 +56,11 @@ pub trait HttpExchange:
 }
 
 /// Top-level provider that combines signing, exchange, and caching.
+///
+/// `Clone` is cheap and shares the credential cache (and the `Clone` HTTP
+/// client), so a runtime can construct one provider and reuse it across requests
+/// — keeping the cache warm instead of re-minting + re-exchanging every call.
+#[derive(Clone)]
 pub struct OidcCredentialProvider<H: HttpExchange> {
     signer: JwtSigner,
     cache: CredentialCache,


### PR DESCRIPTION
Adds `Clone` to `OidcCredentialProvider` and `CredentialCache` (entries behind an `Arc`), so a runtime that rebuilds its dispatch chain per request (e.g. a Cloudflare Worker) can hold one provider in a shared/`static` slot and reuse it — keeping the credential cache warm instead of re-minting + re-running AssumeRoleWithWebIdentity on every call. No behavior change for single-instance use. Consumed by source-cooperative/data.source.coop#147.

🤖 Generated with [Claude Code](https://claude.com/claude-code)