### PR TITLE
chore(core): remove unused ProxyResponseBody::empty()

### DIFF
--- a/crates/core/src/route_handler.rs
+++ b/crates/core/src/route_handler.rs
@@ -37,11 +37,6 @@ impl ProxyResponseBody {
             Self::Bytes(bytes)
         }
     }
-
-    /// Create an empty response body.
-    pub fn empty() -> Self {
-        Self::Empty
-    }
 }
 
 /// The action the handler wants the runtime to take.


### PR DESCRIPTION
## What I'm changing

`ProxyResponseBody::empty()` in `crates/core/src/route_handler.rs` has zero callers anywhere in the workspace — not in production code, not in tests. Call sites construct `ProxyResponseBody::Empty` directly, and `from_bytes` already collapses empty input to `Empty`, so the named constructor is dead public API. Surfaced by a repo-wide over-engineering audit.

## How I did it

- **`crates/core/src/route_handler.rs`** — deleted the `empty()` method (and its doc comment) from the `impl ProxyResponseBody` block. `from_bytes` is left untouched.

## Test plan

- [x] `cargo check -p multistore`
- [x] `cargo clippy -p multistore` (clean)
- [x] `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)