### PR TITLE
chore(oidc-provider): drop unused AwsExchange builder methods

### DIFF
--- a/crates/oidc-provider/src/exchange/aws.rs
+++ b/crates/oidc-provider/src/exchange/aws.rs
@@ -56,30 +56,6 @@ impl AwsExchange {
             ..Default::default()
         }
     }
-
-    /// Override the STS endpoint (e.g. for regional or FIPS endpoints).
-    pub fn with_endpoint(mut self, endpoint: String) -> Self {
-        self.sts_endpoint = endpoint;
-        self
-    }
-
-    /// Override the session name embedded in the assumed-role credentials.
-    pub fn with_session_name(mut self, name: String) -> Self {
-        self.session_name = name;
-        self
-    }
-
-    /// Request a specific credential lifetime (seconds); AWS clamps to the role's max.
-    pub fn with_duration(mut self, seconds: u32) -> Self {
-        self.duration_seconds = Some(seconds);
-        self
-    }
-
-    /// Attach an inline session policy (JSON) that further restricts the session.
-    pub fn with_session_policy(mut self, policy: String) -> Self {
-        self.session_policy = Some(policy);
-        self
-    }
 }
 
 impl<H: HttpExchange> CredentialExchange<H> for AwsExchange {


### PR DESCRIPTION
## What I'm changing

`AwsExchange` in `crates/oidc-provider/src/exchange/aws.rs` exposes four builder methods — `with_endpoint`, `with_session_name`, `with_duration`, `with_session_policy` — that have zero callers anywhere in the workspace. Every `AwsExchange` field is already `pub`, so a caller needing non-default values sets them directly via struct-update syntax on `AwsExchange::new(..)`. The builders are dead flexibility. Surfaced by a repo-wide over-engineering audit.

## How I did it

- **`crates/oidc-provider/src/exchange/aws.rs`** — removed the four `with_*` methods from `impl AwsExchange`, leaving `new()` as the sole constructor.

## Test plan

- [x] `cargo check -p multistore-oidc-provider`
- [x] `cargo clippy -p multistore-oidc-provider` (clean)
- [x] `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)