### PR TITLE
chore(oidc-provider): inline AwsExchange Default into new()

### DIFF
--- a/crates/oidc-provider/src/exchange/aws.rs
+++ b/crates/oidc-provider/src/exchange/aws.rs
@@ -36,24 +36,15 @@ pub struct AwsExchange {
     pub session_policy: Option<String>,
 }
 
-impl Default for AwsExchange {
-    fn default() -> Self {
-        Self {
-            role_arn: String::new(),
-            sts_endpoint: "https://sts.amazonaws.com".into(),
-            session_name: "s3-proxy".into(),
-            duration_seconds: None,
-            session_policy: None,
-        }
-    }
-}
-
 impl AwsExchange {
     /// Create an exchange targeting the given IAM role ARN, using default STS endpoint and session name.
     pub fn new(role_arn: String) -> Self {
         Self {
             role_arn,
-            ..Default::default()
+            sts_endpoint: "https://sts.amazonaws.com".into(),
+            session_name: "s3-proxy".into(),
+            duration_seconds: None,
+            session_policy: None,
         }
     }
 


### PR DESCRIPTION
## What I'm changing

The manual `impl Default for AwsExchange` in `crates/oidc-provider/src/exchange/aws.rs` exists solely to back `new()` (which builds via `..Default::default()`). `AwsExchange::default()` is never called directly anywhere in the workspace, so the standalone impl is an indirection with one consumer. Surfaced by a repo-wide over-engineering audit.

## How I did it

- **`crates/oidc-provider/src/exchange/aws.rs`** — moved the field defaults (`sts_endpoint`, `session_name`, `duration_seconds`, `session_policy`) directly into `new()` and removed the `impl Default` block. `new(role_arn)` remains the sole constructor.

## Test plan

- [x] `cargo check -p multistore-oidc-provider`
- [x] `cargo clippy -p multistore-oidc-provider` (clean)
- [x] `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)