### PR TITLE
chore(oidc-provider): drop unused AzureExchange::with_scope

### DIFF
--- a/crates/oidc-provider/src/exchange/azure.rs
+++ b/crates/oidc-provider/src/exchange/azure.rs
@@ -34,12 +34,6 @@ impl AzureExchange {
         }
     }
 
-    /// Override the OAuth 2.0 scope requested during token exchange.
-    pub fn with_scope(mut self, scope: String) -> Self {
-        self.scope = scope;
-        self
-    }
-
     fn token_endpoint(&self) -> String {
         format!(
             "https://login.microsoftonline.com/{}/oauth2/v2.0/token",


### PR DESCRIPTION
## What I'm changing

`AzureExchange::with_scope` in `crates/oidc-provider/src/exchange/azure.rs` has no callers anywhere in the workspace. The `scope` field is `pub`, so a caller needing a non-default scope sets it directly via struct-update syntax on `AzureExchange::new(..)`. Dead flexibility, surfaced by a repo-wide over-engineering audit.

## How I did it

- **`crates/oidc-provider/src/exchange/azure.rs`** — removed the `with_scope` method from `impl AzureExchange`.

## Test plan

- [x] `cargo check -p multistore-oidc-provider --all-features` (azure module is feature-gated)
- [x] `cargo clippy -p multistore-oidc-provider --all-features` (clean)
- [x] `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)