### PR TITLE
refactor(sts): share JWT-segment decoding between lib and jwks

### DIFF
--- a/crates/sts/src/jwks.rs
+++ b/crates/sts/src/jwks.rs
@@ -103,6 +103,13 @@ fn base64url_decode(input: &str) -> Result<Vec<u8>, ProxyError> {
         .map_err(|e| ProxyError::InvalidOidcToken(format!("base64url decode error: {}", e)))
 }
 
+/// Decode a base64url-encoded JWT segment (header or payload) into JSON.
+pub(crate) fn decode_jwt_segment(segment: &str) -> Result<serde_json::Value, ProxyError> {
+    let bytes = base64url_decode(segment)?;
+    serde_json::from_slice(&bytes)
+        .map_err(|e| ProxyError::InvalidOidcToken(format!("invalid JWT JSON: {}", e)))
+}
+
 /// Build an RSA public key from JWK `n` and `e` components.
 fn rsa_public_key_from_components(n: &str, e: &str) -> Result<RsaPublicKey, ProxyError> {
     let n_bytes = base64url_decode(n)?;
@@ -137,9 +144,7 @@ pub fn verify_token(
     let [header_b64, payload_b64, signature_b64] = [parts[0], parts[1], parts[2]];
 
     // Verify the header specifies RS256
-    let header_bytes = base64url_decode(header_b64)?;
-    let header: serde_json::Value = serde_json::from_slice(&header_bytes)
-        .map_err(|e| ProxyError::InvalidOidcToken(format!("invalid JWT header JSON: {}", e)))?;
+    let header = decode_jwt_segment(header_b64)?;
     let alg = header.get("alg").and_then(|v| v.as_str()).unwrap_or("");
     if alg != "RS256" {
         return Err(ProxyError::InvalidOidcToken(format!(
@@ -162,9 +167,7 @@ pub fn verify_token(
         })?;
 
     // Decode and validate claims
-    let payload_bytes = base64url_decode(payload_b64)?;
-    let claims: serde_json::Value = serde_json::from_slice(&payload_bytes)
-        .map_err(|e| ProxyError::InvalidOidcToken(format!("invalid JWT payload JSON: {}", e)))?;
+    let claims = decode_jwt_segment(payload_b64)?;
 
     // Validate issuer
     let token_issuer = claims.get("iss").and_then(|v| v.as_str()).unwrap_or("");

--- a/crates/sts/src/lib.rs
+++ b/crates/sts/src/lib.rs
@@ -33,7 +33,6 @@ pub mod route_handler;
 pub mod sealed_token;
 pub mod sts;
 
-use base64::Engine;
 pub use jwks::JwksCache;
 use multistore::error::ProxyError;
 use multistore::registry::CredentialRegistry;
@@ -91,15 +90,10 @@ fn jwt_decode_unverified(
         .next()
         .ok_or_else(|| ProxyError::InvalidOidcToken("malformed JWT".into()))?;
 
-    let decode = |s: &str| -> Result<serde_json::Value, ProxyError> {
-        let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
-            .decode(s)
-            .map_err(|e| ProxyError::InvalidOidcToken(format!("base64url decode error: {}", e)))?;
-        serde_json::from_slice(&bytes)
-            .map_err(|e| ProxyError::InvalidOidcToken(format!("invalid JWT JSON: {}", e)))
-    };
-
-    Ok((decode(header_b64)?, decode(payload_b64)?))
+    Ok((
+        jwks::decode_jwt_segment(header_b64)?,
+        jwks::decode_jwt_segment(payload_b64)?,
+    ))
 }
 
 /// Validate an OIDC token and mint temporary credentials.


### PR DESCRIPTION
## What I'm changing

`jwt_decode_unverified` in `crates/sts/src/lib.rs` hand-rolls base64url-decode + JSON-parse for JWT header/payload segments — logic that `crates/sts/src/jwks.rs` already implements (`base64url_decode`) and repeats inline twice inside `verify_token`. Three copies of the same decode, one of them re-deriving what a sibling module already had. Surfaced by a repo-wide over-engineering audit.

## How I did it

- **`crates/sts/src/jwks.rs`** — added `pub(crate) decode_jwt_segment(segment)` (base64url decode + `serde_json::from_slice`) next to `base64url_decode`, and switched `verify_token`'s header and payload decoding to use it.
- **`crates/sts/src/lib.rs`** — replaced the inline `decode` closure in `jwt_decode_unverified` with calls to `jwks::decode_jwt_segment`, and removed the now-unused `use base64::Engine;` import.

Minor behavior note: the header/payload JSON-parse error now reads `invalid JWT JSON` uniformly instead of `invalid JWT header JSON` / `invalid JWT payload JSON`. No test asserts on those strings.

## Test plan

- [x] `cargo check -p multistore-sts`
- [x] `cargo clippy -p multistore-sts` (clean)
- [x] `cargo test -p multistore-sts` — 25 passed, 0 failed
- [x] `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)