### PR TITLE
refactor(examples/lambda): dedup body_to_bytes

### DIFF
--- a/examples/lambda/src/client.rs
+++ b/examples/lambda/src/client.rs
@@ -38,7 +38,7 @@ impl LambdaBackend {
 }
 
 /// Collect a Lambda body into bytes.
-async fn body_to_bytes(body: Body) -> Result<Bytes, Box<dyn std::error::Error>> {
+pub async fn body_to_bytes(body: Body) -> Result<Bytes, Box<dyn std::error::Error>> {
     match body {
         Body::Empty => Ok(Bytes::new()),
         Body::Text(s) => Ok(Bytes::from(s)),

--- a/examples/lambda/src/main.rs
+++ b/examples/lambda/src/main.rs
@@ -19,7 +19,7 @@
 
 mod client;
 
-use client::{LambdaBackend, ReqwestHttpExchange};
+use client::{body_to_bytes, LambdaBackend, ReqwestHttpExchange};
 use lambda_http::{service_fn, Body, Error, Request, Response};
 use multistore::proxy::{GatewayResponse, ProxyGateway};
 use multistore::route_handler::{ProxyResponseBody, ProxyResult, RequestInfo};
@@ -156,13 +156,4 @@ fn build_lambda_response(result: ProxyResult) -> Response<Body> {
     }
 
     builder.body(body).unwrap()
-}
-
-/// Collect a Lambda body into bytes.
-async fn body_to_bytes(body: Body) -> Result<bytes::Bytes, Box<dyn std::error::Error>> {
-    match body {
-        Body::Empty => Ok(bytes::Bytes::new()),
-        Body::Text(s) => Ok(bytes::Bytes::from(s)),
-        Body::Binary(b) => Ok(bytes::Bytes::from(b)),
-    }
 }


### PR DESCRIPTION
## What I'm changing

The Lambda example defined the same `body_to_bytes` helper twice — once in `examples/lambda/src/main.rs` and once in `examples/lambda/src/client.rs`, byte-for-byte identical. Surfaced by a repo-wide over-engineering audit.

## How I did it

- **`examples/lambda/src/client.rs`** — made `body_to_bytes` `pub` (it was already used internally by `LambdaBackend::forward`).
- **`examples/lambda/src/main.rs`** — imported `body_to_bytes` from `client` and deleted the local copy.

## Test plan

- [x] `cargo check -p multistore-lambda`
- [x] `cargo clippy -p multistore-lambda` (clean)
- [x] `cargo fmt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)