### PR TITLE
chore: remove dead dependency declarations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1227,7 +1227,6 @@ dependencies = [
 name = "multistore-oidc-provider"
 version = "0.4.0"
 dependencies = [
- "async-trait",
  "base64",
  "chrono",
  "multistore",
@@ -1268,10 +1267,8 @@ dependencies = [
  "object_store",
  "reqwest",
  "serde",
- "thiserror",
  "tokio",
  "toml",
- "tower-service",
  "tracing",
  "tracing-subscriber",
 ]
@@ -1293,7 +1290,6 @@ name = "multistore-sts"
 version = "0.4.0"
 dependencies = [
  "aes-gcm",
- "async-trait",
  "base64",
  "chrono",
  "http",
@@ -1305,7 +1301,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
- "thiserror",
  "tokio",
  "tracing",
  "url",

--- a/crates/oidc-provider/Cargo.toml
+++ b/crates/oidc-provider/Cargo.toml
@@ -12,7 +12,6 @@ gcp = []
 
 [dependencies]
 multistore.workspace = true
-async-trait.workspace = true
 thiserror.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/sts/Cargo.toml
+++ b/crates/sts/Cargo.toml
@@ -8,8 +8,6 @@ description = "OIDC/STS authentication for the S3 proxy gateway"
 [dependencies]
 multistore.workspace = true
 aes-gcm.workspace = true
-async-trait.workspace = true
-thiserror.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 chrono.workspace = true

--- a/examples/server/Cargo.toml
+++ b/examples/server/Cargo.toml
@@ -12,7 +12,6 @@ multistore-static-config.workspace = true
 multistore-sts.workspace = true
 multistore-oidc-provider.workspace = true
 axum = { workspace = true, features = ["json", "tokio", "http1", "http2"] }
-tower-service.workspace = true
 tokio.workspace = true
 http.workspace = true
 bytes.workspace = true
@@ -21,7 +20,6 @@ tracing-subscriber.workspace = true
 serde.workspace = true
 toml.workspace = true
 reqwest = { workspace = true, features = ["stream"] }
-thiserror.workspace = true
 object_store.workspace = true
 futures.workspace = true
 http-body-util.workspace = true


### PR DESCRIPTION
## What I'm changing

Several crate manifests declare dependencies their source never references. Dead `[dependencies]` entries inflate the build graph and mislead readers about what a crate actually needs. Surfaced by a repo-wide over-engineering audit (each was confirmed absent from the crate's `src/`).

## How I did it

Removed these unused declarations:

- **`examples/server/Cargo.toml`** — `tower-service` (zero references anywhere in the repo) and `thiserror` (server defines no error types).
- **`crates/sts/Cargo.toml`** — `async-trait` and `thiserror` (the crate uses neither).
- **`crates/oidc-provider/Cargo.toml`** — `async-trait` (no `#[async_trait]` usage). `thiserror` is **kept** — it is used by the crate's error enums.

All five remain `[workspace.dependencies]` entries consumed by other crates (`async-trait` by core/cf-workers, `thiserror` by core/oidc), so this only prunes the dead per-crate declarations — no workspace dep is fully removed.

## Test plan

- [x] `cargo check -p multistore-sts -p multistore-server`
- [x] `cargo check -p multistore-oidc-provider --all-features`
- [x] `cargo clippy -p multistore-server` (clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)