### PR TITLE
fix(ci): give production its own OIDC issuer so federation works

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -17,6 +17,13 @@ jobs:
       worker_name: multistore
       wrangler_config: wrangler.deploy.toml
       environment: production
+      # Production self-issues OIDC at its own public URL. Unlike preview/staging
+      # (which share STAGING_OIDC_ISSUER and one IAM OIDC provider), this issuer is
+      # unique to production: an AWS IAM OIDC provider must be registered for this
+      # exact URL (audience sts.amazonaws.com) and added to the backend role's
+      # trust policy with sub=`multistore`. Without it the worker deploys with OIDC
+      # disabled and the federated-test bucket 500s (see tests/smoke/test_federation.py).
+      oidc_issuer_override: https://multistore.development-seed.workers.dev
     secrets:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/docs/deployment/cloudflare-workers.md
+++ b/docs/deployment/cloudflare-workers.md
@@ -86,6 +86,15 @@ printf '%s' "$OIDC_KEY" | gh secret set OIDC_PROVIDER_KEY --env staging --repo <
 printf '%s' "$OIDC_KEY" | gh secret set OIDC_PROVIDER_KEY --env preview --repo <owner>/<repo>
 ```
 
+Production is **not** part of that shared issuer. The production deploy sets
+`OIDC_PROVIDER_ISSUER` to the production worker's own URL (`oidc_issuer_override` in
+`production.yml`), so it self-issues and self-serves JWKS independently of staging.
+This requires a **dedicated** AWS IAM OIDC provider registered for that production URL
+(audience `sts.amazonaws.com`), added to the backend role's trust policy with
+`sub` = the bucket's `oidc_subject` — see [Backend Auth](../auth/backend-auth.md) for the
+provider + trust-policy setup. Until that provider exists, OIDC backend buckets return
+HTTP 500 in production (`tests/smoke/test_federation.py` fails).
+
 ### Environment Variables
 
 | Variable | Required | Description |

--- a/examples/cf-workers/wrangler.deploy.toml
+++ b/examples/cf-workers/wrangler.deploy.toml
@@ -40,12 +40,13 @@ region = "us-east-1"
 skip_signature = "true"
 
 # Backend-federation test bucket. The proxy mints its own OIDC assertion (iss =
-# OIDC_PROVIDER_ISSUER, the stable staging issuer) and assumes an AWS IAM role
-# via AssumeRoleWithWebIdentity to serve this private bucket — no long-lived
-# backend keys. Exercised by tests/smoke/test_federation.py on every preview and
-# staging deploy. Replace oidc_role_arn + bucket_name (+ region/endpoint) with
+# OIDC_PROVIDER_ISSUER — preview/staging share STAGING_OIDC_ISSUER; production
+# self-issues at its own worker URL) and assumes an AWS IAM role via
+# AssumeRoleWithWebIdentity to serve this private bucket — no long-lived backend
+# keys. Exercised by tests/smoke/test_federation.py on every preview, staging, and
+# production deploy. Replace oidc_role_arn + bucket_name (+ region/endpoint) with
 # your test resources; these are not secrets. The role's trust policy must trust
-# the STAGING_OIDC_ISSUER IAM OIDC provider with `sub` = oidc_subject and
+# each deploy environment's IAM OIDC provider with `sub` = oidc_subject and
 # audience sts.amazonaws.com, and grant s3:GetObject/s3:ListBucket on the bucket.
 [[vars.PROXY_CONFIG.buckets]]
 allowed_roles = []


### PR DESCRIPTION
## What I'm changing

The v0.5.0 **production** smoke test failed (`test_federation_serves_private_object`, HTTP 500) while the **staging** run of the *identical commit* passed minutes earlier. Root cause: the production deploy never set `OIDC_PROVIDER_ISSUER`.

Only `staging.yml` and `preview.yml` inject the issuer (via `oidc_issuer_override: ${{ vars.STAGING_OIDC_ISSUER }}`); `production.yml` passed nothing, and `wrangler.deploy.toml` doesn't define it in `[vars]`. With no issuer, `load_oidc_auth` (`examples/cf-workers/src/lib.rs`) returns `MaybeOidcAuth::Disabled`, so any `auth_type=oidc` bucket returns `ProxyError::ConfigError` → 500 (`crates/oidc-provider/src/backend_auth.rs`).

This never surfaced before because `tests/smoke/test_federation.py` was added (PR #57) *after* the v0.4.0 production tag — v0.5.0 was the first time federation ran against production. The deployed AWS infra was never the problem.

The established pattern is "issuer == the worker's own public URL" (`STAGING_OIDC_ISSUER` is literally `https://multistore-staging.development-seed.workers.dev`). Production just needs the same self-issuing setup with its own dedicated IAM OIDC provider.

## How I did it

- **`.github/workflows/production.yml`** — added `oidc_issuer_override: https://multistore.development-seed.workers.dev` (the production worker's own URL). A literal rather than a repo var because, unlike `STAGING_OIDC_ISSUER` (shared by preview + staging), this value is unique to production. Comment spells out the AWS provider/trust-policy requirement.
- **`examples/cf-workers/wrangler.deploy.toml`** — corrected the `federated-test` comment that claimed the issuer is always "the stable staging issuer" and the test runs on "preview and staging" only; now reflects production self-issuing and running the test too.
- **`docs/deployment/cloudflare-workers.md`** — documented that production is **not** part of the shared preview/staging issuer and requires its own registered IAM OIDC provider + trust-policy entry, linking to the Backend Auth setup.

## Required follow-up (AWS — not in this PR)

The code change is inert until a dedicated provider exists. On account `470592060578`:

1. Register an IAM OIDC provider for `https://multistore.development-seed.workers.dev` (client-id `sts.amazonaws.com`).
2. Add a trust-policy statement to `role/multistore-github-ci` mirroring the staging one, conditioned on `…workers.dev:aud = sts.amazonaws.com` and `…workers.dev:sub = multistore`.

Order to green: merge → next `v*` tag deploys (worker begins serving JWKS at the production URL) → AWS provider + trust in place → re-run smoke test.

## Test plan

- [x] `production.yml` parses as valid YAML; `oidc_issuer_override` resolves to the production URL.
- [ ] After AWS setup: production tag deploy + `tests/smoke/test_federation.py` returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)