### PR TITLE
fix(deps): bump quinn-proto to 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "multistore"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "base64",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-cf-workers"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-cf-workers-example"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "console_error_panic_hook",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-lambda"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "http",
@@ -1213,7 +1213,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-metering"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "futures",
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-oidc-provider"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "base64",
  "chrono",
@@ -1245,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-path-mapping"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "multistore",
  "percent-encoding",
@@ -1254,7 +1254,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-server"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "axum",
  "bytes",
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-static-config"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "multistore",
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-sts"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -1610,9 +1610,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## What I'm changing

CI's `Audit` job (`cargo audit`) started failing on **every** run — including the release-please PR #86 — after [RUSTSEC-2026-0185](https://rustsec.org/advisories/RUSTSEC-2026-0185) was published 2026-06-22. `quinn-proto 0.11.14` has a high-severity (7.5) **remote memory-exhaustion** bug from unbounded out-of-order stream reassembly. No code of ours changed; a new advisory dropped against an existing transitive dependency. The fix is to move to `>=0.11.15`.

## How I did it

- **`Cargo.lock`** — `cargo update -p quinn-proto` (0.11.14 → 0.11.15, the advisory's fixed release). quinn-proto is a target-specific transitive dep, so no manifest change is needed.
- The same command also synced the workspace crates in `Cargo.lock` from `0.4.0` → `0.5.0`: the v0.5.0 release bumped `Cargo.toml` but never committed the regenerated lockfile, so this PR also clears that pre-existing drift.

## Test plan

- [x] `cargo audit` exits 0 (only the two pre-existing, CI-allowed `rand` unsound *warnings* remain).
- [x] `cargo check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)