### PR TITLE
feat: accept multiple audiences for STS role validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "multistore"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -1146,7 +1146,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-cf-workers"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1169,7 +1169,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-cf-workers-example"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bytes",
  "console_error_panic_hook",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-lambda"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bytes",
  "http",
@@ -1213,7 +1213,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-metering"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bytes",
  "futures",
@@ -1225,7 +1225,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-oidc-provider"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "base64",
  "chrono",
@@ -1245,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-path-mapping"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "multistore",
  "percent-encoding",
@@ -1254,7 +1254,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-server"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "axum",
  "bytes",
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-static-config"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chrono",
  "multistore",
@@ -1288,7 +1288,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-sts"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -124,9 +124,10 @@ pub struct RoleConfig {
     pub trusted_oidc_issuers: Vec<String>,
 
     /// Audience claim values accepted for this role. A token is accepted if its
-    /// `aud` claim matches any entry; empty means no audience restriction.
-    /// Deserializes from a single string or a list, and from the legacy
-    /// `required_audience` key, for backward compatibility.
+    /// `aud` claim matches any entry; empty (or absent/null) means no audience
+    /// restriction. Accepts a single string or a list, and the legacy
+    /// `required_audience` key, for backward compatibility — set one key or the
+    /// other, not both (specifying both is a config error).
     #[serde(
         default,
         alias = "required_audience",
@@ -160,9 +161,13 @@ where
         One(String),
         Many(Vec<String>),
     }
-    Ok(match OneOrMany::deserialize(deserializer)? {
-        OneOrMany::One(s) => vec![s],
-        OneOrMany::Many(v) => v,
+    // `Option` so an explicit `null` (e.g. legacy `required_audience: null`)
+    // maps to "unrestricted", matching the old `Option<String>` behavior
+    // instead of failing to parse.
+    Ok(match Option::<OneOrMany>::deserialize(deserializer)? {
+        None => vec![],
+        Some(OneOrMany::One(s)) => vec![s],
+        Some(OneOrMany::Many(v)) => v,
     })
 }
 
@@ -568,5 +573,58 @@ mod tests {
         let dbg = format!("{config:?}");
         assert!(!dbg.contains("super-secret"));
         assert!(!dbg.contains("super-session"));
+    }
+
+    /// Parse a `RoleConfig` from JSON with the given audience field snippet
+    /// (e.g. `,"required_audiences":["x"]`), so the deserialization edge cases
+    /// for the audience config can be exercised directly.
+    fn parse_role(audience_field: &str) -> Result<RoleConfig, serde_json::Error> {
+        serde_json::from_str(&format!(
+            r#"{{"role_id":"r","name":"R","max_session_duration_secs":3600{audience_field}}}"#
+        ))
+    }
+
+    #[test]
+    fn audiences_accepts_legacy_single_string() {
+        let r = parse_role(r#","required_audience":"x""#).unwrap();
+        assert_eq!(r.required_audiences, vec!["x".to_string()]);
+    }
+
+    #[test]
+    fn audiences_accepts_single_string_and_list() {
+        assert_eq!(
+            parse_role(r#","required_audiences":"x""#)
+                .unwrap()
+                .required_audiences,
+            vec!["x".to_string()]
+        );
+        assert_eq!(
+            parse_role(r#","required_audiences":["x","y"]"#)
+                .unwrap()
+                .required_audiences,
+            vec!["x".to_string(), "y".to_string()]
+        );
+    }
+
+    #[test]
+    fn audiences_absent_or_null_is_unrestricted() {
+        // Absent, or an explicit null on either key, means "no restriction" —
+        // matching the old `Option<String>` behavior rather than erroring.
+        assert!(parse_role("").unwrap().required_audiences.is_empty());
+        assert!(parse_role(r#","required_audiences":null"#)
+            .unwrap()
+            .required_audiences
+            .is_empty());
+        assert!(parse_role(r#","required_audience":null"#)
+            .unwrap()
+            .required_audiences
+            .is_empty());
+    }
+
+    #[test]
+    fn audiences_both_keys_is_an_error() {
+        // Setting both the legacy and new keys fails loudly rather than
+        // silently picking one, so a leftover key during migration is caught.
+        assert!(parse_role(r#","required_audience":"x","required_audiences":["y"]"#).is_err());
     }
 }

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -123,8 +123,16 @@ pub struct RoleConfig {
     #[serde(default)]
     pub trusted_oidc_issuers: Vec<String>,
 
-    /// Required audience claim value.
-    pub required_audience: Option<String>,
+    /// Audience claim values accepted for this role. A token is accepted if its
+    /// `aud` claim matches any entry; empty means no audience restriction.
+    /// Deserializes from a single string or a list, and from the legacy
+    /// `required_audience` key, for backward compatibility.
+    #[serde(
+        default,
+        alias = "required_audience",
+        deserialize_with = "deserialize_audiences"
+    )]
+    pub required_audiences: Vec<String>,
 
     /// Conditions on the subject claim (glob patterns).
     /// e.g., "repo:myorg/myrepo:ref:refs/heads/main"
@@ -137,6 +145,25 @@ pub struct RoleConfig {
 
     /// Maximum session duration in seconds.
     pub max_session_duration_secs: u64,
+}
+
+/// Deserialize a role's accepted audiences from either a single string or a
+/// list, so legacy `required_audience: "x"` configs keep working alongside
+/// `required_audiences: ["x", "y"]`.
+fn deserialize_audiences<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum OneOrMany {
+        One(String),
+        Many(Vec<String>),
+    }
+    Ok(match OneOrMany::deserialize(deserializer)? {
+        OneOrMany::One(s) => vec![s],
+        OneOrMany::Many(v) => v,
+    })
 }
 
 /// Defines what a credential is allowed to access.

--- a/crates/static-config/src/lib.rs
+++ b/crates/static-config/src/lib.rs
@@ -284,7 +284,7 @@ mod tests {
                 role_id: "my-role".into(),
                 name: "My Role".into(),
                 trusted_oidc_issuers: vec!["https://issuer.example.com".into()],
-                required_audience: None,
+                required_audiences: vec![],
                 subject_conditions: vec![],
                 allowed_scopes: vec![],
                 max_session_duration_secs: 3600,

--- a/crates/sts/README.md
+++ b/crates/sts/README.md
@@ -28,6 +28,6 @@ Client signs S3 requests with temp creds
 Roles define who can assume them:
 
 - **`trusted_oidc_issuers`** — accepted OIDC providers (e.g., `https://token.actions.githubusercontent.com`)
-- **`required_audience`** — required `aud` claim
+- **`required_audiences`** — accepted `aud` claim values (string or list); a token passes if its `aud` matches any. Empty/omitted means unrestricted. Legacy `required_audience` (single string) still accepted.
 - **`subject_conditions`** — glob patterns for the `sub` claim (e.g., `repo:myorg/*`)
 - **`allowed_scopes`** — buckets, prefixes, and actions the minted credentials grant

--- a/crates/sts/src/jwks.rs
+++ b/crates/sts/src/jwks.rs
@@ -120,6 +120,24 @@ fn rsa_public_key_from_components(n: &str, e: &str) -> Result<RsaPublicKey, Prox
         .map_err(|e| ProxyError::InvalidOidcToken(format!("invalid RSA key: {}", e)))
 }
 
+/// Whether a token's `aud` claim is acceptable for a set of accepted audiences.
+///
+/// An empty `accepted` set means no audience restriction (always allowed). The
+/// `aud` claim may be a single string or an array; it passes if any of its
+/// values is in `accepted`.
+fn audience_allowed(aud_claim: Option<&serde_json::Value>, accepted: &[String]) -> bool {
+    if accepted.is_empty() {
+        return true;
+    }
+    match aud_claim {
+        Some(serde_json::Value::String(aud)) => accepted.iter().any(|a| a == aud),
+        Some(serde_json::Value::Array(auds)) => auds
+            .iter()
+            .any(|a| a.as_str().is_some_and(|s| accepted.iter().any(|x| x == s))),
+        _ => false,
+    }
+}
+
 /// Verify a JWT using the provided JWK.
 pub fn verify_token(
     token: &str,
@@ -178,21 +196,12 @@ pub fn verify_token(
         )));
     }
 
-    // Validate audience if required
-    if let Some(ref required_aud) = role.required_audience {
-        let aud_valid = match claims.get("aud") {
-            Some(serde_json::Value::String(aud)) => aud == required_aud,
-            Some(serde_json::Value::Array(auds)) => auds
-                .iter()
-                .any(|a| a.as_str() == Some(required_aud.as_str())),
-            _ => false,
-        };
-        if !aud_valid {
-            return Err(ProxyError::InvalidOidcToken(format!(
-                "audience mismatch: expected {}",
-                required_aud
-            )));
-        }
+    // Validate audience if restricted.
+    if !audience_allowed(claims.get("aud"), &role.required_audiences) {
+        return Err(ProxyError::InvalidOidcToken(format!(
+            "audience mismatch: expected one of {:?}",
+            role.required_audiences
+        )));
     }
 
     // Validate time-based claims with clock skew tolerance
@@ -305,5 +314,37 @@ impl JwksCache {
             }
         }
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::audience_allowed;
+    use serde_json::json;
+
+    #[test]
+    fn empty_accepted_means_no_restriction() {
+        assert!(audience_allowed(None, &[]));
+        assert!(audience_allowed(Some(&json!("anything")), &[]));
+    }
+
+    #[test]
+    fn string_aud_matches_any_accepted() {
+        let accepted = vec!["frontend".to_string(), "cli".to_string()];
+        assert!(audience_allowed(Some(&json!("frontend")), &accepted));
+        assert!(audience_allowed(Some(&json!("cli")), &accepted));
+        assert!(!audience_allowed(Some(&json!("other")), &accepted));
+    }
+
+    #[test]
+    fn array_aud_matches_when_any_overlaps() {
+        let accepted = vec!["cli".to_string()];
+        assert!(audience_allowed(Some(&json!(["other", "cli"])), &accepted));
+        assert!(!audience_allowed(Some(&json!(["a", "b"])), &accepted));
+    }
+
+    #[test]
+    fn missing_or_restricted_mismatch_is_rejected() {
+        assert!(!audience_allowed(None, &["cli".to_string()]));
     }
 }

--- a/docs/auth/proxy-auth.md
+++ b/docs/auth/proxy-auth.md
@@ -80,7 +80,7 @@ When a client calls `AssumeRoleWithWebIdentity`:
 3. The proxy fetches the issuer's JWKS endpoint and verifies the JWT signature (RS256)
 4. The proxy evaluates the trust policy:
    - **Issuer**: must be in the role's `trusted_oidc_issuers`
-   - **Audience**: if `required_audience` is set on the role, the token's `aud` claim must match
+   - **Audience**: if the role's `required_audiences` is non-empty, the token's `aud` claim must match at least one of the accepted values
    - **Subject**: the token's `sub` claim must match at least one of the role's `subject_conditions` (supports `*` glob wildcards)
 5. The proxy mints temporary credentials scoped to the role's `allowed_scopes`
 6. If `SESSION_TOKEN_KEY` is configured, the credentials are AES-256-GCM encrypted into the session token (see [Sealed Session Tokens](./sealed-tokens))
@@ -125,7 +125,7 @@ The proxy works with any OIDC-compliant identity provider that serves a JWKS end
 
 1. The provider's issuer URL (must serve `/.well-known/openid-configuration` with a `jwks_uri`)
 2. The `sub` claim format for configuring `subject_conditions`
-3. Optionally, the audience claim value for `required_audience`
+3. Optionally, the audience claim value(s) for `required_audiences`
 
 <details>
 <summary><strong>GitHub Actions</strong> — OIDC tokens for CI/CD workflows</summary>
@@ -137,7 +137,7 @@ The proxy works with any OIDC-compliant identity provider that serves a JWKS end
 role_id = "github-actions-deployer"
 name = "GitHub Actions Deploy Role"
 trusted_oidc_issuers = ["https://token.actions.githubusercontent.com"]
-required_audience = "sts.s3proxy.example.com"
+required_audiences = ["sts.s3proxy.example.com"]
 subject_conditions = [
     "repo:myorg/myapp:ref:refs/heads/main",
     "repo:myorg/myapp:ref:refs/heads/release/*",
@@ -209,7 +209,7 @@ jobs:
 role_id = "auth0-user"
 name = "Auth0 User"
 trusted_oidc_issuers = ["https://your-tenant.auth0.com/"]
-required_audience = "https://s3proxy.example.com"
+required_audiences = ["https://s3proxy.example.com"]
 subject_conditions = ["*"]  # Or restrict by user ID patterns
 max_session_duration_secs = 3600
 
@@ -289,7 +289,7 @@ actions = ["get_object", "head_object", "put_object", "list_bucket"]
 
 - **Issuer URL**: `https://cognito-idp.{region}.amazonaws.com/{user-pool-id}`
 - **Subject claim**: Cognito user UUID
-- **Audience**: the App Client ID (set `required_audience` to match)
+- **Audience**: the App Client ID (set `required_audiences` to match)
 
 </details>
 

--- a/docs/configuration/roles.md
+++ b/docs/configuration/roles.md
@@ -9,7 +9,7 @@ Roles define trust policies for OIDC token exchange via `AssumeRoleWithWebIdenti
 role_id = "github-actions-deployer"
 name = "GitHub Actions Deploy Role"
 trusted_oidc_issuers = ["https://token.actions.githubusercontent.com"]
-required_audience = "sts.s3proxy.example.com"
+required_audiences = ["sts.s3proxy.example.com"]
 subject_conditions = [
     "repo:myorg/myapp:ref:refs/heads/main",
     "repo:myorg/infrastructure:*",
@@ -34,7 +34,7 @@ actions = ["get_object", "head_object"]
 | `role_id` | string | Yes | Identifier used as the `RoleArn` in STS requests |
 | `name` | string | Yes | Human-readable display name |
 | `trusted_oidc_issuers` | string[] | Validated as required | OIDC provider URLs whose tokens are accepted. Deserializes fine when absent, but config validation rejects a role with no issuers (it could never accept a token). |
-| `required_audience` | string | No | If set, the token's `aud` claim must match |
+| `required_audiences` | string \| string[] | No | Accepted `aud` claim values. A token passes if its `aud` matches any entry; empty or omitted means no audience restriction. Accepts a single string or a list. The legacy `required_audience` key (single string) is still accepted for backward compatibility — set one key or the other, not both. |
 | `subject_conditions` | string[] | No | Glob patterns matched against the `sub` claim. When omitted or empty, the subject check is skipped entirely and all subjects match. |
 | `max_session_duration_secs` | integer | Yes | Maximum session lifetime granted by this role |
 | `allowed_scopes` | AccessScope[] | Yes | Buckets, prefixes, and actions granted |
@@ -46,7 +46,7 @@ When a client calls `AssumeRoleWithWebIdentity`, the proxy evaluates the JWT aga
 1. **Issuer** — The JWT's `iss` claim must match one of `trusted_oidc_issuers`
 2. **Algorithm** — Only RS256 is supported
 3. **Signature** — Verified against the issuer's JWKS (fetched and cached)
-4. **Audience** — If `required_audience` is set, the JWT's `aud` claim must match
+4. **Audience** — If `required_audiences` is non-empty, the JWT's `aud` claim must match at least one of the accepted values
 5. **Subject** — If `subject_conditions` is non-empty, the JWT's `sub` claim must match at least one pattern. If it is empty (or omitted), the subject check is skipped and all subjects pass.
 
 If any check fails, the STS request returns an error.

--- a/docs/reference/config-example.md
+++ b/docs/reference/config-example.md
@@ -70,7 +70,7 @@ container_name = "public-datasets"
 role_id = "github-actions-deployer"         # Used as RoleArn in STS requests
 name = "GitHub Actions Deploy Role"
 trusted_oidc_issuers = ["https://token.actions.githubusercontent.com"]
-required_audience = "sts.s3proxy.example.com"  # Token's `aud` must match
+required_audiences = ["sts.s3proxy.example.com"]  # Token's `aud` must match one of these
 
 # Glob patterns for the `sub` claim
 subject_conditions = [


### PR DESCRIPTION
## What

`RoleConfig.required_audience: Option<String>` → **`required_audiences: Vec<String>`**. A token is accepted if its `aud` claim matches **any** entry; an empty list means no audience restriction. This lets a single STS role trust more than one OAuth client (e.g. a web app *and* a CLI).

## Compatibility
- **Serialized configs are backward compatible**: a single string *or* the legacy `required_audience` key both deserialize into the list (via `#[serde(alias = "required_audience", deserialize_with = …)]` accepting one-or-many).
- **Rust API is breaking**: code constructing `RoleConfig` must use `required_audiences`. Hence `feat!` / BREAKING CHANGE.

## Validation
Extracted a pure `audience_allowed(aud_claim, accepted)` helper (string or array `aud`, any-match, empty = unrestricted) with unit tests. `cargo test` + `clippy` green across the workspace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)