### PR TITLE
fix(proxy): stream-resign aws-chunked uploads instead of decoding

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,11 @@ on:
         required: false
         type: string
         default: ""
+      smoke_write_bucket:
+        description: "Virtual bucket for the multipart write smoke test; empty skips it"
+        required: false
+        type: string
+        default: ""
       set_secrets:
         description: "Whether to set worker secrets after deploy"
         required: false
@@ -112,6 +117,10 @@ jobs:
       # here on both preview (PR) and staging deploys, against the stable
       # staging OIDC issuer — see preview.yml / staging.yml.
       FEDERATION_TEST_KEY: ${{ vars.FEDERATION_TEST_KEY }}
+      # Virtual bucket the multipart write smoke test uploads to
+      # (TestMultipartUpload). Set per-caller via the `smoke_write_bucket` input
+      # (preview.yml passes `smoke-writable`); empty -> the test self-skips.
+      SMOKE_WRITE_BUCKET: ${{ inputs.smoke_write_bucket }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -21,6 +21,8 @@ jobs:
       worker_name: multistore-proxy-pr-${{ github.event.pull_request.number }}
       wrangler_config: wrangler.deploy.toml
       environment: preview
+      # Run the real-S3 multipart write smoke test on every preview.
+      smoke_write_bucket: smoke-writable
       # Mint tokens with the STABLE staging issuer rather than this PR's own URL.
       # All deployments share OIDC_PROVIDER_KEY, so a preview can sign assertions
       # whose `iss` is the staging URL; AWS then validates them against the

--- a/crates/core/src/aws_chunked.rs
+++ b/crates/core/src/aws_chunked.rs
@@ -1,0 +1,90 @@
+//! Detection of AWS SigV4 streaming ("aws-chunked") uploads.
+//!
+//! Modern AWS clients (aws-cli ≥ 2.23, recent SDKs) send `PutObject`/`UploadPart`
+//! bodies as `Content-Encoding: aws-chunked` framing with an
+//! `x-amz-content-sha256: STREAMING-…` sentinel rather than a plain payload. S3
+//! only de-chunks that framing for a request signed with the matching streaming
+//! sentinel, so the proxy must re-sign the request seed (not presign) and stream
+//! the framing through untouched — see `ProxyGateway::build_streaming_forward`.
+
+use http::HeaderMap;
+
+/// How a streaming ("aws-chunked") upload's chunks are authenticated — which
+/// decides whether the proxy can forward the framing after re-signing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum StreamingUpload {
+    /// `STREAMING-UNSIGNED-PAYLOAD[-TRAILER]` — chunks are framed but not
+    /// individually signed. The proxy can re-sign the request seed with the
+    /// backend credentials and stream the framing through for S3 to de-chunk.
+    Unsigned,
+    /// `STREAMING-AWS4-HMAC-SHA256-PAYLOAD[-TRAILER]` — each chunk carries a
+    /// signature chained from the client's signing key, which cannot survive the
+    /// proxy re-signing the request to the backend with different credentials.
+    /// The proxy cannot forward these.
+    Signed,
+}
+
+/// Classify a request body from its `x-amz-content-sha256`, returning `None`
+/// for an ordinary (non-streaming) upload.
+pub(crate) fn streaming_upload(headers: &HeaderMap) -> Option<StreamingUpload> {
+    let variant = headers
+        .get("x-amz-content-sha256")?
+        .to_str()
+        .ok()?
+        .strip_prefix("STREAMING-")?;
+    Some(if variant.contains("UNSIGNED") {
+        StreamingUpload::Unsigned
+    } else {
+        StreamingUpload::Signed
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn headers(content_sha256: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        if !content_sha256.is_empty() {
+            h.insert("x-amz-content-sha256", content_sha256.parse().unwrap());
+        }
+        h
+    }
+
+    #[test]
+    fn unsigned_streaming_is_unsigned() {
+        // The aws-cli/SDK default (CRC64NVME trailer), and the no-trailer form.
+        assert_eq!(
+            streaming_upload(&headers("STREAMING-UNSIGNED-PAYLOAD-TRAILER")),
+            Some(StreamingUpload::Unsigned)
+        );
+        assert_eq!(
+            streaming_upload(&headers("STREAMING-UNSIGNED-PAYLOAD")),
+            Some(StreamingUpload::Unsigned)
+        );
+    }
+
+    #[test]
+    fn signed_streaming_is_signed() {
+        assert_eq!(
+            streaming_upload(&headers("STREAMING-AWS4-HMAC-SHA256-PAYLOAD")),
+            Some(StreamingUpload::Signed)
+        );
+        assert_eq!(
+            streaming_upload(&headers("STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER")),
+            Some(StreamingUpload::Signed)
+        );
+    }
+
+    #[test]
+    fn non_streaming_is_none() {
+        assert_eq!(streaming_upload(&headers("UNSIGNED-PAYLOAD")), None);
+        assert_eq!(
+            streaming_upload(&headers(
+                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+            )),
+            None
+        );
+        assert_eq!(streaming_upload(&headers("")), None);
+    }
+}

--- a/crates/core/src/aws_chunked.rs
+++ b/crates/core/src/aws_chunked.rs
@@ -77,24 +77,13 @@ mod tests {
                 "STREAMING-AWS4-HMAC-SHA256-PAYLOAD"
             ))
         );
-        assert_eq!(
-            streaming_upload(&headers("STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER")),
-            Some((
-                StreamingUpload::Signed,
-                "STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER"
-            ))
-        );
     }
 
     #[test]
     fn non_streaming_is_none() {
+        // Anything without the `STREAMING-` prefix (a plain hash, `UNSIGNED-PAYLOAD`,
+        // or a missing header) is not a streaming upload.
         assert_eq!(streaming_upload(&headers("UNSIGNED-PAYLOAD")), None);
-        assert_eq!(
-            streaming_upload(&headers(
-                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-            )),
-            None
-        );
         assert_eq!(streaming_upload(&headers("")), None);
     }
 }

--- a/crates/core/src/aws_chunked.rs
+++ b/crates/core/src/aws_chunked.rs
@@ -24,19 +24,19 @@ pub(crate) enum StreamingUpload {
     Signed,
 }
 
-/// Classify a request body from its `x-amz-content-sha256`, returning `None`
-/// for an ordinary (non-streaming) upload.
-pub(crate) fn streaming_upload(headers: &HeaderMap) -> Option<StreamingUpload> {
-    let variant = headers
-        .get("x-amz-content-sha256")?
-        .to_str()
-        .ok()?
-        .strip_prefix("STREAMING-")?;
-    Some(if variant.contains("UNSIGNED") {
+/// Classify a request body from its `x-amz-content-sha256`, returning the
+/// upload kind together with the sentinel value (so the caller can reuse it as
+/// the seed's payload hash without re-reading it). `None` for an ordinary
+/// (non-streaming) upload.
+pub(crate) fn streaming_upload(headers: &HeaderMap) -> Option<(StreamingUpload, &str)> {
+    let sentinel = headers.get("x-amz-content-sha256")?.to_str().ok()?;
+    let variant = sentinel.strip_prefix("STREAMING-")?;
+    let kind = if variant.contains("UNSIGNED") {
         StreamingUpload::Unsigned
     } else {
         StreamingUpload::Signed
-    })
+    };
+    Some((kind, sentinel))
 }
 
 #[cfg(test)]
@@ -54,13 +54,17 @@ mod tests {
     #[test]
     fn unsigned_streaming_is_unsigned() {
         // The aws-cli/SDK default (CRC64NVME trailer), and the no-trailer form.
+        // The sentinel is returned verbatim (the `-TRAILER` suffix matters).
         assert_eq!(
             streaming_upload(&headers("STREAMING-UNSIGNED-PAYLOAD-TRAILER")),
-            Some(StreamingUpload::Unsigned)
+            Some((
+                StreamingUpload::Unsigned,
+                "STREAMING-UNSIGNED-PAYLOAD-TRAILER"
+            ))
         );
         assert_eq!(
             streaming_upload(&headers("STREAMING-UNSIGNED-PAYLOAD")),
-            Some(StreamingUpload::Unsigned)
+            Some((StreamingUpload::Unsigned, "STREAMING-UNSIGNED-PAYLOAD"))
         );
     }
 
@@ -68,11 +72,17 @@ mod tests {
     fn signed_streaming_is_signed() {
         assert_eq!(
             streaming_upload(&headers("STREAMING-AWS4-HMAC-SHA256-PAYLOAD")),
-            Some(StreamingUpload::Signed)
+            Some((
+                StreamingUpload::Signed,
+                "STREAMING-AWS4-HMAC-SHA256-PAYLOAD"
+            ))
         );
         assert_eq!(
             streaming_upload(&headers("STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER")),
-            Some(StreamingUpload::Signed)
+            Some((
+                StreamingUpload::Signed,
+                "STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER"
+            ))
         );
     }
 

--- a/crates/core/src/backend/request_signer.rs
+++ b/crates/core/src/backend/request_signer.rs
@@ -152,6 +152,3 @@ pub fn hash_payload(payload: &[u8]) -> String {
 
 /// The SigV4 sentinel for unsigned payloads (used with streaming uploads).
 pub const UNSIGNED_PAYLOAD: &str = "UNSIGNED-PAYLOAD";
-
-/// The SigV4 sentinel for streaming payloads.
-pub const STREAMING_PAYLOAD: &str = "STREAMING-AWS4-HMAC-SHA256-PAYLOAD";

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -23,6 +23,7 @@
 
 pub mod api;
 pub mod auth;
+pub(crate) mod aws_chunked;
 pub mod backend;
 pub mod error;
 pub mod maybe_send;

--- a/crates/core/src/proxy.rs
+++ b/crates/core/src/proxy.rs
@@ -968,13 +968,19 @@ where
         request_id: &str,
     ) -> Result<Option<ForwardRequest>, ProxyError> {
         match crate::aws_chunked::streaming_upload(original_headers) {
-            Some(crate::aws_chunked::StreamingUpload::Unsigned) => Ok(Some(
-                self.build_streaming_forward(config, operation, original_headers, request_id)
-                    .await?,
+            Some((crate::aws_chunked::StreamingUpload::Unsigned, sentinel)) => Ok(Some(
+                self.build_streaming_forward(
+                    config,
+                    operation,
+                    sentinel,
+                    original_headers,
+                    request_id,
+                )
+                .await?,
             )),
-            Some(crate::aws_chunked::StreamingUpload::Signed) => Err(ProxyError::NotImplemented(
-                SIGNED_AWS_CHUNKED_UNSUPPORTED.to_string(),
-            )),
+            Some((crate::aws_chunked::StreamingUpload::Signed, _)) => Err(
+                ProxyError::NotImplemented(SIGNED_AWS_CHUNKED_UNSUPPORTED.to_string()),
+            ),
             None => Ok(None),
         }
     }
@@ -1010,9 +1016,22 @@ where
         &self,
         config: &BucketConfig,
         operation: &S3Operation,
+        payload_hash: &str,
         original_headers: &HeaderMap,
         request_id: &str,
     ) -> Result<ForwardRequest, ProxyError> {
+        // This path hardcodes S3 SigV4 seed signing (`build_backend_url` +
+        // `sign_s3_request`). A non-S3 backend can't be presigned for aws-chunked
+        // either, so a streaming upload there has no valid path — reject it
+        // rather than mis-sign. (UploadPart already gates on this earlier; this
+        // also covers the PutObject streaming arm.)
+        if !config.is_s3_backend() {
+            return Err(ProxyError::InvalidRequest(format!(
+                "aws-chunked streaming uploads are not supported for '{}' backends",
+                config.backend_type
+            )));
+        }
+
         let url = url::Url::parse(&build_backend_url(config, operation)?)
             .map_err(|e| ProxyError::Internal(format!("invalid backend URL: {e}")))?;
 
@@ -1029,15 +1048,8 @@ where
         }
 
         // Re-sign the seed with the backend creds, reusing the client's exact
-        // streaming sentinel (the `-TRAILER` suffix matters) as the payload
-        // hash. The caller has classified this as a streaming upload, so the
-        // header is present.
-        let payload_hash = original_headers
-            .get("x-amz-content-sha256")
-            .and_then(|v| v.to_str().ok())
-            .ok_or_else(|| {
-                ProxyError::Internal("aws-chunked upload missing x-amz-content-sha256".into())
-            })?;
+        // streaming sentinel (`payload_hash`, the `-TRAILER` suffix matters) as
+        // the canonical-request payload hash.
         sign_s3_request(
             &Method::PUT,
             url.as_str(),
@@ -1548,9 +1560,16 @@ mod tests {
             "secret_access_key".into(),
             "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into(),
         );
+        // A bucket named `azure-*` resolves to a non-S3 backend so tests can
+        // exercise the non-S3 rejection paths; everything else is S3.
+        let backend_type = if name.starts_with("azure") {
+            "azure"
+        } else {
+            "s3"
+        };
         BucketConfig {
             name: name.to_string(),
-            backend_type: "s3".into(),
+            backend_type: backend_type.into(),
             backend_prefix: None,
             anonymous_access: true,
             allowed_roles: vec![],
@@ -1877,10 +1896,49 @@ mod tests {
                     None,
                 )
                 .await;
-            assert!(
-                matches!(action, HandlerAction::Forward(_)),
-                "unsigned aws-chunked UploadPart should stream via re-sign, not buffer"
-            );
+            match action {
+                HandlerAction::Forward(fwd) => {
+                    // The arm-specific behavior: the part query must survive into
+                    // the forwarded backend URL (otherwise S3 treats it as a PUT).
+                    let q = fwd.url.query().unwrap_or("");
+                    assert!(
+                        q.contains("partNumber=1") && q.contains("uploadId=abc"),
+                        "UploadPart forward must carry partNumber/uploadId, got query {q:?}"
+                    );
+                    assert_eq!(
+                        fwd.headers.get("x-amz-content-sha256").unwrap(),
+                        "STREAMING-UNSIGNED-PAYLOAD-TRAILER"
+                    );
+                }
+                other => panic!(
+                    "expected Forward (stream via re-sign, not buffer), got {:?}",
+                    std::mem::discriminant(&other)
+                ),
+            }
+        });
+    }
+
+    #[test]
+    fn streaming_put_on_non_s3_backend_is_rejected() {
+        run(async {
+            let gw = gateway();
+            let headers = unsigned_aws_chunked_headers();
+            // `azure-bucket` resolves to a non-S3 backend (see test_bucket_config).
+            // A streaming upload there has no presign or seed-sign path, so it
+            // must reject cleanly rather than mis-route into S3 signing.
+            let action = gw
+                .resolve_request(Method::PUT, "/azure-bucket/test.md", None, &headers, None)
+                .await;
+            match action {
+                HandlerAction::Response(r) => assert_eq!(
+                    r.status, 400,
+                    "aws-chunked PUT to a non-S3 backend should be rejected, not mis-signed"
+                ),
+                other => panic!(
+                    "expected Response(400), got {:?}",
+                    std::mem::discriminant(&other)
+                ),
+            }
         });
     }
 

--- a/crates/core/src/proxy.rs
+++ b/crates/core/src/proxy.rs
@@ -1215,10 +1215,23 @@ where
 
         let mut headers = HeaderMap::new();
 
-        // Forward relevant headers
-        for header_name in &["content-type", "content-length", "content-md5"] {
-            if let Some(val) = pending.original_headers.get(*header_name) {
-                headers.insert(*header_name, val.clone());
+        // Forward entity headers plus the client's flexible-checksum headers.
+        // Modern AWS SDKs/CLI enable CRC32 integrity checksums by default:
+        // CreateMultipartUpload declares the algorithm (`x-amz-checksum-algorithm`)
+        // and CompleteMultipartUpload echoes the per-part / full-object checksums
+        // (`x-amz-checksum-type`, `x-amz-checksum-crc32`, …). Dropping them leaves
+        // the MPU with no checksum context while the parts are stored *with*
+        // checksums, so S3 rejects the completion with `InvalidPart`. This raw
+        // path signs every header present (see `sign_s3_request`), so forwarding
+        // them here is safe — unlike the presigned PutObject path, where S3
+        // rejects unsigned `x-amz-*` headers.
+        for (name, val) in pending.original_headers.iter() {
+            let n = name.as_str();
+            if matches!(n, "content-type" | "content-length" | "content-md5")
+                || n.starts_with("x-amz-checksum")
+                || n == "x-amz-sdk-checksum-algorithm"
+            {
+                headers.insert(name.clone(), val.clone());
             }
         }
         headers.insert(http::header::USER_AGENT, self.user_agent.parse().unwrap());
@@ -2324,6 +2337,129 @@ mod tests {
             assert!(
                 captured.lock().unwrap().is_none(),
                 "backend should be skipped"
+            );
+        });
+    }
+
+    /// Backend that captures the headers forwarded to `send_raw`.
+    #[derive(Clone)]
+    struct CaptureHeadersBackend {
+        captured: Arc<std::sync::Mutex<Option<HeaderMap>>>,
+    }
+
+    impl ProxyBackend for CaptureHeadersBackend {
+        type ResponseBody = ();
+        type Body = ();
+
+        async fn forward(
+            &self,
+            _request: ForwardRequest,
+            _body: (),
+        ) -> Result<ForwardResponse<()>, ProxyError> {
+            unimplemented!()
+        }
+
+        fn create_paginated_store(
+            &self,
+            _config: &BucketConfig,
+        ) -> Result<Box<dyn PaginatedListStore>, ProxyError> {
+            unimplemented!()
+        }
+
+        fn create_signer(&self, config: &BucketConfig) -> Result<Arc<dyn Signer>, ProxyError> {
+            crate::backend::build_signer(config)
+        }
+
+        async fn send_raw(
+            &self,
+            _method: http::Method,
+            _url: String,
+            headers: HeaderMap,
+            _body: Bytes,
+        ) -> Result<RawResponse, ProxyError> {
+            *self.captured.lock().unwrap() = Some(headers);
+            Ok(RawResponse {
+                status: 200,
+                headers: HeaderMap::new(),
+                body: Bytes::new(),
+            })
+        }
+    }
+
+    /// Regression guard: modern AWS CLI/SDK enable CRC32 integrity checksums by
+    /// default, so CompleteMultipartUpload carries `x-amz-checksum-*` headers.
+    /// They must be forwarded to *and signed for* the backend — dropping them
+    /// leaves the upload with no checksum context and S3 fails the completion
+    /// with `InvalidPart`.
+    #[test]
+    fn complete_multipart_forwards_and_signs_checksum_headers() {
+        use crate::types::AuthenticatedIdentity;
+        run(async {
+            let captured = Arc::new(std::sync::Mutex::new(None));
+            let backend = CaptureHeadersBackend {
+                captured: captured.clone(),
+            };
+            let gw = ProxyGateway::new(backend, MockRegistry, MockCreds, None);
+
+            let mut original_headers = HeaderMap::new();
+            original_headers.insert("content-type", "application/xml".parse().unwrap());
+            original_headers.insert("x-amz-checksum-crc32", "AAAAAA==".parse().unwrap());
+            original_headers.insert("x-amz-checksum-type", "FULL_OBJECT".parse().unwrap());
+            original_headers.insert("x-amz-sdk-checksum-algorithm", "CRC32".parse().unwrap());
+            // The client's own credentials must never be forwarded; the proxy
+            // re-signs with the backend creds.
+            original_headers.insert(
+                "authorization",
+                "AWS4-HMAC-SHA256 client-bogus".parse().unwrap(),
+            );
+
+            let pending = PendingRequest {
+                operation: S3Operation::CompleteMultipartUpload {
+                    bucket: "test-bucket".into(),
+                    key: "big.dmg".into(),
+                    upload_id: "upload-1".into(),
+                },
+                bucket_config: test_bucket_config("test-bucket"),
+                original_headers,
+                request_id: "rid".into(),
+                identity: ResolvedIdentity::Authenticated(AuthenticatedIdentity {
+                    principal_name: "tester".into(),
+                    allowed_scopes: vec![],
+                }),
+            };
+
+            let body = Bytes::from_static(
+                br#"<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>"abc"</ETag><ChecksumCRC32>AAAAAA==</ChecksumCRC32></Part></CompleteMultipartUpload>"#,
+            );
+
+            let result = gw.handle_with_body(pending, body).await;
+            assert_eq!(result.status, 200);
+
+            let sent = captured
+                .lock()
+                .unwrap()
+                .clone()
+                .expect("backend was called");
+
+            // 1. The checksum headers reach the backend.
+            assert_eq!(sent.get("x-amz-checksum-crc32").unwrap(), "AAAAAA==");
+            assert_eq!(sent.get("x-amz-checksum-type").unwrap(), "FULL_OBJECT");
+            assert_eq!(sent.get("x-amz-sdk-checksum-algorithm").unwrap(), "CRC32");
+
+            // 2. The client's Authorization is replaced by a fresh proxy signature.
+            let auth = sent.get("authorization").unwrap().to_str().unwrap();
+            assert!(
+                auth.starts_with("AWS4-HMAC-SHA256 Credential="),
+                "expected re-signed Authorization, got: {auth}"
+            );
+
+            // 3. The checksum headers are part of SignedHeaders — without this S3
+            //    ignores them and the completion fails with InvalidPart.
+            assert!(
+                auth.contains("x-amz-checksum-crc32")
+                    && auth.contains("x-amz-checksum-type")
+                    && auth.contains("x-amz-sdk-checksum-algorithm"),
+                "checksum headers missing from SignedHeaders: {auth}"
             );
         });
     }

--- a/crates/core/src/proxy.rs
+++ b/crates/core/src/proxy.rs
@@ -77,6 +77,13 @@ use uuid::Uuid;
 /// TTL for presigned URLs. Short because they're used immediately.
 const PRESIGNED_URL_TTL: Duration = Duration::from_secs(300);
 
+/// Rejection for aws-chunked uploads with *signed* chunks: each chunk signature
+/// is bound to the client's key and can't be re-signed to the backend creds.
+const SIGNED_AWS_CHUNKED_UNSUPPORTED: &str =
+    "aws-chunked uploads with signed chunks (x-amz-content-sha256: \
+     STREAMING-AWS4-HMAC-SHA256-PAYLOAD) are not supported; configure the client \
+     to use a trailing checksum (the default) or multipart";
+
 /// Default User-Agent header value sent with outbound backend requests.
 ///
 /// Identifies multistore as the caller to backend object stores, useful for
@@ -758,6 +765,16 @@ where
             .as_deref()
             .expect("bucket_config must be set for bucket-targeted operations");
 
+        // The deferred-body operations (UploadPart/multipart/batch-delete) all
+        // build the same pending request from the current context.
+        let pending = || PendingRequest {
+            operation: operation.clone(),
+            bucket_config: bucket_config.clone(),
+            original_headers: original_headers.clone(),
+            request_id: request_id.to_string(),
+            identity: ctx.identity.clone(),
+        };
+
         match operation {
             S3Operation::GetObject { key, .. } => {
                 let fwd = self
@@ -801,6 +818,15 @@ where
             }
             S3Operation::PutObject { key, .. } => {
                 self.check_upload_size(original_headers)?;
+                // An `aws-chunked` body can't be presigned (S3 only de-chunks a
+                // streaming-signed request, so a presigned PUT would store the
+                // raw chunk envelope) — stream-re-sign or reject it.
+                if let Some(fwd) = self
+                    .try_streaming_forward(bucket_config, operation, original_headers, request_id)
+                    .await?
+                {
+                    return Ok(HandlerAction::Forward(fwd));
+                }
                 let fwd = self
                     .build_forward(
                         Method::PUT,
@@ -856,28 +882,27 @@ where
                     .await?;
                 Ok(HandlerAction::Response(result))
             }
-            // Multipart operations need the request body
+            // UploadPart carries the part body, which modern clients also send
+            // as aws-chunked — same streaming re-sign / reject handling as
+            // PutObject. A plain part still buffers via the raw-signed path.
+            S3Operation::UploadPart { .. } => {
+                Self::require_s3_backend(bucket_config)?;
+                self.check_upload_size(original_headers)?;
+                if let Some(fwd) = self
+                    .try_streaming_forward(bucket_config, operation, original_headers, request_id)
+                    .await?
+                {
+                    return Ok(HandlerAction::Forward(fwd));
+                }
+                Ok(HandlerAction::NeedsBody(pending()))
+            }
+            // Multipart control operations carry only a small (XML or empty)
+            // body, which is buffered and re-signed.
             S3Operation::CreateMultipartUpload { .. }
-            | S3Operation::UploadPart { .. }
             | S3Operation::CompleteMultipartUpload { .. }
             | S3Operation::AbortMultipartUpload { .. } => {
-                if !bucket_config.is_s3_backend() {
-                    return Err(ProxyError::InvalidRequest(format!(
-                        "multipart operations not supported for '{}' backends",
-                        bucket_config.backend_type
-                    )));
-                }
-                // UploadPart carries the part body; reject oversized parts up
-                // front. (Create/Complete/Abort bodies are small and won't trip
-                // a sane limit.)
-                self.check_upload_size(original_headers)?;
-                Ok(HandlerAction::NeedsBody(PendingRequest {
-                    operation: operation.clone(),
-                    bucket_config: bucket_config.clone(),
-                    original_headers: original_headers.clone(),
-                    request_id: request_id.to_string(),
-                    identity: ctx.identity.clone(),
-                }))
+                Self::require_s3_backend(bucket_config)?;
+                Ok(HandlerAction::NeedsBody(pending()))
             }
             // Batch delete needs the body to read the key list and authorize
             // each key individually.
@@ -891,13 +916,7 @@ where
                 // The body is buffered whole; bound it like other uploads. The
                 // key count is additionally capped when the body is parsed.
                 self.check_upload_size(original_headers)?;
-                Ok(HandlerAction::NeedsBody(PendingRequest {
-                    operation: operation.clone(),
-                    bucket_config: bucket_config.clone(),
-                    original_headers: original_headers.clone(),
-                    request_id: request_id.to_string(),
-                    identity: ctx.identity.clone(),
-                }))
+                Ok(HandlerAction::NeedsBody(pending()))
             }
             _ => Err(ProxyError::Internal("unexpected operation".into())),
         }
@@ -933,6 +952,111 @@ where
             method,
             url,
             headers: fwd_headers,
+            request_id: request_id.to_string(),
+        })
+    }
+
+    /// Handle a body-bearing PUT (PutObject/UploadPart) whose body is
+    /// `aws-chunked`: stream an unsigned-payload upload through after re-signing
+    /// the seed (returns the `Forward`), reject a signed-chunk one, or return
+    /// `None` for a plain body so the caller takes its own path.
+    async fn try_streaming_forward(
+        &self,
+        config: &BucketConfig,
+        operation: &S3Operation,
+        original_headers: &HeaderMap,
+        request_id: &str,
+    ) -> Result<Option<ForwardRequest>, ProxyError> {
+        match crate::aws_chunked::streaming_upload(original_headers) {
+            Some(crate::aws_chunked::StreamingUpload::Unsigned) => Ok(Some(
+                self.build_streaming_forward(config, operation, original_headers, request_id)
+                    .await?,
+            )),
+            Some(crate::aws_chunked::StreamingUpload::Signed) => Err(ProxyError::NotImplemented(
+                SIGNED_AWS_CHUNKED_UNSUPPORTED.to_string(),
+            )),
+            None => Ok(None),
+        }
+    }
+
+    /// Reject multipart operations on non-S3 backends (an S3-only feature).
+    fn require_s3_backend(config: &BucketConfig) -> Result<(), ProxyError> {
+        if config.is_s3_backend() {
+            Ok(())
+        } else {
+            Err(ProxyError::InvalidRequest(format!(
+                "multipart operations not supported for '{}' backends",
+                config.backend_type
+            )))
+        }
+    }
+
+    /// Build a header-signed streaming PUT for an `aws-chunked`
+    /// *unsigned-payload* upload (PutObject or UploadPart).
+    ///
+    /// These can't be presigned (a presigned URL signs `UNSIGNED-PAYLOAD`, which
+    /// S3 won't de-chunk) and shouldn't be buffered (memory). Instead we re-sign
+    /// only the request seed with the backend credentials — reusing the client's
+    /// `STREAMING-…` `x-amz-content-sha256` and the de-chunk headers — and let
+    /// the runtime stream the chunk framing through untouched for S3 to
+    /// de-chunk. Zero-copy, no buffering.
+    ///
+    /// Only headers that are stable through the runtime's streaming fetch are
+    /// signed. `Content-Length` is forwarded but left *unsigned*: the transfer
+    /// framing is the runtime's to manage, so signing it risks a mismatch — S3
+    /// sizes the payload from `x-amz-decoded-content-length` and the chunk
+    /// framing regardless.
+    async fn build_streaming_forward(
+        &self,
+        config: &BucketConfig,
+        operation: &S3Operation,
+        original_headers: &HeaderMap,
+        request_id: &str,
+    ) -> Result<ForwardRequest, ProxyError> {
+        let url = url::Url::parse(&build_backend_url(config, operation)?)
+            .map_err(|e| ProxyError::Internal(format!("invalid backend URL: {e}")))?;
+
+        let mut headers = HeaderMap::new();
+        for name in &[
+            "content-type",
+            "content-encoding",
+            "x-amz-decoded-content-length",
+            "x-amz-trailer",
+        ] {
+            if let Some(v) = original_headers.get(*name) {
+                headers.insert(*name, v.clone());
+            }
+        }
+
+        // Re-sign the seed with the backend creds, reusing the client's exact
+        // streaming sentinel (the `-TRAILER` suffix matters) as the payload
+        // hash. The caller has classified this as a streaming upload, so the
+        // header is present.
+        let payload_hash = original_headers
+            .get("x-amz-content-sha256")
+            .and_then(|v| v.to_str().ok())
+            .ok_or_else(|| {
+                ProxyError::Internal("aws-chunked upload missing x-amz-content-sha256".into())
+            })?;
+        sign_s3_request(
+            &Method::PUT,
+            url.as_str(),
+            &mut headers,
+            config,
+            payload_hash,
+        )?;
+
+        // Forwarded unsigned (see the doc comment).
+        if let Some(cl) = original_headers.get(http::header::CONTENT_LENGTH) {
+            headers.insert(http::header::CONTENT_LENGTH, cl.clone());
+        }
+        headers.insert(http::header::USER_AGENT, self.user_agent.parse().unwrap());
+
+        tracing::debug!(path = url.path(), "aws-chunked write via streaming re-sign");
+        Ok(ForwardRequest {
+            method: Method::PUT,
+            url,
+            headers,
             request_id: request_id.to_string(),
         })
     }
@@ -1666,6 +1790,96 @@ mod tests {
             assert!(
                 matches!(action, HandlerAction::Forward(_)),
                 "with no limit configured, large PUT should still forward"
+            );
+        });
+    }
+
+    /// An aws-chunked unsigned-payload upload (the modern aws-cli default) is
+    /// re-signed for the backend and streamed through — not buffered, not
+    /// presigned. The forwarded request reuses the streaming sentinel and
+    /// carries a fresh backend Authorization plus the de-chunk headers.
+    fn unsigned_aws_chunked_headers() -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert("content-encoding", "aws-chunked".parse().unwrap());
+        headers.insert(
+            "x-amz-content-sha256",
+            "STREAMING-UNSIGNED-PAYLOAD-TRAILER".parse().unwrap(),
+        );
+        headers.insert("content-length", "52".parse().unwrap());
+        headers.insert("x-amz-decoded-content-length", "7".parse().unwrap());
+        headers.insert("x-amz-trailer", "x-amz-checksum-crc64nvme".parse().unwrap());
+        headers
+    }
+
+    #[test]
+    fn put_unsigned_aws_chunked_streams_via_resign() {
+        run(async {
+            let gw = gateway();
+            let headers = unsigned_aws_chunked_headers();
+            let action = gw
+                .resolve_request(Method::PUT, "/test-bucket/test.md", None, &headers, None)
+                .await;
+            match action {
+                HandlerAction::Forward(fwd) => {
+                    assert_eq!(fwd.method, Method::PUT);
+                    // Re-signed seed reusing the streaming sentinel (not decoded).
+                    assert_eq!(
+                        fwd.headers.get("x-amz-content-sha256").unwrap(),
+                        "STREAMING-UNSIGNED-PAYLOAD-TRAILER"
+                    );
+                    // De-chunk headers preserved, fresh backend auth attached.
+                    assert_eq!(fwd.headers.get("content-encoding").unwrap(), "aws-chunked");
+                    assert!(fwd.headers.contains_key("x-amz-decoded-content-length"));
+                    assert!(fwd.headers.contains_key("authorization"));
+                }
+                other => panic!("expected Forward, got {:?}", std::mem::discriminant(&other)),
+            }
+        });
+    }
+
+    #[test]
+    fn put_signed_aws_chunked_is_rejected() {
+        run(async {
+            let gw = gateway();
+            let mut headers = HeaderMap::new();
+            headers.insert("content-encoding", "aws-chunked".parse().unwrap());
+            headers.insert(
+                "x-amz-content-sha256",
+                "STREAMING-AWS4-HMAC-SHA256-PAYLOAD".parse().unwrap(),
+            );
+            let action = gw
+                .resolve_request(Method::PUT, "/test-bucket/test.md", None, &headers, None)
+                .await;
+            match action {
+                HandlerAction::Response(r) => assert_eq!(
+                    r.status, 501,
+                    "signed aws-chunked uploads should be rejected with NotImplemented"
+                ),
+                other => panic!(
+                    "expected Response(501), got {:?}",
+                    std::mem::discriminant(&other)
+                ),
+            }
+        });
+    }
+
+    #[test]
+    fn upload_part_unsigned_aws_chunked_streams_via_resign() {
+        run(async {
+            let gw = gateway();
+            let headers = unsigned_aws_chunked_headers();
+            let action = gw
+                .resolve_request(
+                    Method::PUT,
+                    "/test-bucket/key.bin",
+                    Some("partNumber=1&uploadId=abc"),
+                    &headers,
+                    None,
+                )
+                .await;
+            assert!(
+                matches!(action, HandlerAction::Forward(_)),
+                "unsigned aws-chunked UploadPart should stream via re-sign, not buffer"
             );
         });
     }

--- a/crates/core/src/proxy.rs
+++ b/crates/core/src/proxy.rs
@@ -968,16 +968,29 @@ where
         request_id: &str,
     ) -> Result<Option<ForwardRequest>, ProxyError> {
         match crate::aws_chunked::streaming_upload(original_headers) {
-            Some((crate::aws_chunked::StreamingUpload::Unsigned, sentinel)) => Ok(Some(
-                self.build_streaming_forward(
-                    config,
-                    operation,
-                    sentinel,
-                    original_headers,
-                    request_id,
-                )
-                .await?,
-            )),
+            Some((crate::aws_chunked::StreamingUpload::Unsigned, sentinel)) => {
+                // Streaming re-sign hardcodes S3 SigV4 seed signing; a non-S3
+                // backend can't be presigned for aws-chunked either, so a
+                // streaming upload there has no valid path — reject rather than
+                // mis-sign. (UploadPart gates on this earlier too; this also
+                // covers PutObject's streaming arm.)
+                if !config.is_s3_backend() {
+                    return Err(ProxyError::InvalidRequest(format!(
+                        "aws-chunked streaming uploads are not supported for '{}' backends",
+                        config.backend_type
+                    )));
+                }
+                Ok(Some(
+                    self.build_streaming_forward(
+                        config,
+                        operation,
+                        sentinel,
+                        original_headers,
+                        request_id,
+                    )
+                    .await?,
+                ))
+            }
             Some((crate::aws_chunked::StreamingUpload::Signed, _)) => Err(
                 ProxyError::NotImplemented(SIGNED_AWS_CHUNKED_UNSUPPORTED.to_string()),
             ),
@@ -1020,18 +1033,9 @@ where
         original_headers: &HeaderMap,
         request_id: &str,
     ) -> Result<ForwardRequest, ProxyError> {
-        // This path hardcodes S3 SigV4 seed signing (`build_backend_url` +
-        // `sign_s3_request`). A non-S3 backend can't be presigned for aws-chunked
-        // either, so a streaming upload there has no valid path — reject it
-        // rather than mis-sign. (UploadPart already gates on this earlier; this
-        // also covers the PutObject streaming arm.)
-        if !config.is_s3_backend() {
-            return Err(ProxyError::InvalidRequest(format!(
-                "aws-chunked streaming uploads are not supported for '{}' backends",
-                config.backend_type
-            )));
-        }
-
+        // Caller (`try_streaming_forward`) has already gated on an S3 backend;
+        // this path hardcodes S3 SigV4 seed signing (`build_backend_url` +
+        // `sign_s3_request`).
         let url = url::Url::parse(&build_backend_url(config, operation)?)
             .map_err(|e| ProxyError::Internal(format!("invalid backend URL: {e}")))?;
 

--- a/examples/cf-workers/wrangler.deploy.toml
+++ b/examples/cf-workers/wrangler.deploy.toml
@@ -62,6 +62,33 @@ bucket_name = "multistore-test-bucket"
 endpoint = "https://s3.us-west-2.amazonaws.com"
 region = "us-west-2"
 
+# Writable bucket for the multipart write smoke test
+# (tests/smoke/test_smoke.py::TestMultipartUpload). The regression it guards —
+# dropped `x-amz-checksum-*` headers causing `InvalidPart` on
+# CompleteMultipartUpload — only reproduces against *real* AWS S3; MinIO accepts
+# the inconsistent upload, so it can't live in the MinIO integration suite.
+#
+# Reuses the federated-test backend bucket + OIDC role, namespaced under a
+# `smoke-writable/` prefix. The role's policy already grants PutObject/GetObject/
+# DeleteObject/ListBucket (which cover Create/Upload/Complete); add
+# `s3:AbortMultipartUpload` so failed uploads clean up instead of orphaning
+# parts. To activate, set SMOKE_WRITE_BUCKET=smoke-writable in the smoke job;
+# until then the test self-skips.
+[[vars.PROXY_CONFIG.buckets]]
+allowed_roles = ["github-actions"]
+anonymous_access = false
+backend_type = "s3"
+backend_prefix = "smoke-writable/"
+name = "smoke-writable"
+
+[vars.PROXY_CONFIG.buckets.backend_options]
+auth_type = "oidc"
+oidc_role_arn = "arn:aws:iam::470592060578:role/multistore-github-ci"
+oidc_subject = "multistore"
+bucket_name = "multistore-test-bucket"
+endpoint = "https://s3.us-west-2.amazonaws.com"
+region = "us-west-2"
+
 [[vars.PROXY_CONFIG.credentials]]
 access_key_id = "AKPROXY00000EXAMPLE"
 secret_access_key = "EXAMPLE000000000000"
@@ -86,6 +113,23 @@ trusted_oidc_issuers = [
 [[vars.PROXY_CONFIG.roles.allowed_scopes]]
 actions = ["get_object", "head_object", "list_bucket"]
 bucket = "cholmes"
+prefixes = []
+
+# Write access for the multipart write smoke test (see the `smoke-writable`
+# bucket above). Multipart needs the create/upload/complete/abort actions.
+[[vars.PROXY_CONFIG.roles.allowed_scopes]]
+actions = [
+  "get_object",
+  "head_object",
+  "put_object",
+  "delete_object",
+  "list_bucket",
+  "create_multipart_upload",
+  "upload_part",
+  "complete_multipart_upload",
+  "abort_multipart_upload",
+]
+bucket = "smoke-writable"
 prefixes = []
 
 [[vars.PROXY_CONFIG.roles]]

--- a/tests/smoke/test_smoke.py
+++ b/tests/smoke/test_smoke.py
@@ -7,15 +7,35 @@ Requires environment variables:
 """
 
 import os
+import uuid
 import xml.etree.ElementTree as ET
+from io import BytesIO
 
 import boto3
 import pytest
 import requests
+from boto3.s3.transfer import TransferConfig
 from botocore.config import Config
 from botocore.exceptions import ClientError
 
 DEPLOY_URL = os.environ.get("DEPLOY_URL", "http://localhost:8787")
+
+# S3 requires every multipart part except the last to be at least 5 MiB.
+MIB = 1024 * 1024
+
+# A writable bucket on a *real* AWS-S3 backend, addressable by the smoke
+# identity. The integration suite already covers multipart against MinIO, but
+# MinIO does not enforce S3's flexible-checksum validation — the exact gap that
+# let the dropped-`x-amz-checksum-*` bug through — so this regression must run
+# against real S3. The preview's other buckets are read-only (`skip_signature`)
+# mirrors, so this is opt-in: set SMOKE_WRITE_BUCKET to the writable bucket's
+# virtual name (see `smoke-writable` in examples/cf-workers/wrangler.deploy.toml).
+WRITE_BUCKET = os.environ.get("SMOKE_WRITE_BUCKET")
+
+requires_write_bucket = pytest.mark.skipif(
+    not WRITE_BUCKET,
+    reason="SMOKE_WRITE_BUCKET not set (no writable real-S3 bucket configured)",
+)
 
 
 def assume_role(role_arn: str, oidc_token: str) -> dict:
@@ -229,3 +249,46 @@ class TestRangeRequests:
                 f"CF may be serving a cached full-body response."
             )
             assert resp.headers.get("content-range") is not None
+
+
+@requires_oidc
+@requires_write_bucket
+class TestMultipartUpload:
+    """Multipart upload against a real S3 backend.
+
+    Regression guard for the dropped flexible-checksum headers bug: modern AWS
+    CLI/SDK enable CRC32 integrity checksums by default, so a multipart upload
+    sends a per-part checksum on each UploadPart and echoes them on
+    CompleteMultipartUpload. If the proxy drops the `x-amz-checksum-*` headers,
+    the upload is initialized with no checksum context while the parts carry
+    checksums, and S3 rejects completion with `InvalidPart`. Checksums are
+    forced on here (`ChecksumAlgorithm=CRC32`) so the path is exercised
+    regardless of the client's botocore default.
+
+    This is what `aws s3 cp` of a large file does and what originally surfaced
+    the bug; MinIO (the integration backend) does not reproduce it.
+    """
+
+    def test_multipart_roundtrip_with_checksums(self, actions_credentials):
+        client = s3_client(actions_credentials)
+        key = f"smoke-multipart-{uuid.uuid4()}.bin"
+        # 6 MiB → two parts (5 MiB + 1 MiB) at a 5 MiB chunk size.
+        body = bytes(i % 251 for i in range(6 * MIB))
+        config = TransferConfig(
+            multipart_threshold=5 * MIB,
+            multipart_chunksize=5 * MIB,
+            max_concurrency=1,
+            use_threads=False,
+        )
+        try:
+            client.upload_fileobj(
+                BytesIO(body),
+                WRITE_BUCKET,
+                key,
+                Config=config,
+                ExtraArgs={"ChecksumAlgorithm": "CRC32"},
+            )
+            resp = client.get_object(Bucket=WRITE_BUCKET, Key=key)
+            assert resp["Body"].read() == body
+        finally:
+            client.delete_object(Bucket=WRITE_BUCKET, Key=key)


### PR DESCRIPTION
## Problem

Writes through the proxy are corrupted. Reading back an object uploaded with a current aws-cli shows the raw chunk envelope instead of the payload:

```
$ printf 'hello!\n' | aws s3 cp - s3://acct/bucket/test.md
$ aws s3 cp s3://acct/bucket/test.md -
7
hello!

0
x-amz-checksum-crc64nvme:bh/Fr0C6NuQ=
```

## Root cause

Modern AWS clients (aws-cli ≥ 2.23 and recent SDKs, by **default**, via CRC64NVME checksums) frame `PutObject`/`UploadPart` bodies as `Content-Encoding: aws-chunked` with a streaming sentinel (`x-amz-content-sha256: STREAMING-…`):

```
<hex-size>[;chunk-signature=…]\r\n <data> \r\n … 0\r\n <trailer>\r\n \r\n
```

The proxy forwarded these bodies untouched (PutObject via a presigned URL, UploadPart via a re-signed raw request). S3 only de-chunks a request signed with a matching streaming sentinel, so it stored the chunk envelope verbatim as the object. Every aws-chunked write was corrupted.

## Approach: stream-resign (zero-copy)

The chunks in the default variant (`STREAMING-UNSIGNED-PAYLOAD-TRAILER`) are framed but **not individually signed**. So rather than buffer + decode the body (memory-heavy on the Cloudflare Workers ceiling), the proxy re-signs only the request **seed** with the backend credentials, reuses the client's streaming sentinel + the de-chunk headers (`content-encoding`, `x-amz-decoded-content-length`, `x-amz-trailer`), and streams the chunk framing straight through for S3 to de-chunk.

- **Zero-copy**: the worker never buffers or hashes the payload — only the request seed is signed (O(1)). Memory- and CPU-flat regardless of object size.
- **PutObject and UploadPart** share the path (`build_streaming_forward` + `try_streaming_forward`); a plain (non-streaming) body keeps its existing presigned / buffered path.
- **Content-Length is forwarded but left unsigned**: the runtime owns the streaming transfer framing, so signing it risks a mismatch; S3 sizes the payload from `x-amz-decoded-content-length` and the chunk framing.

## Signed chunks → rejected, not corrupted

Signed-chunk uploads (`STREAMING-AWS4-HMAC-SHA256-PAYLOAD`) carry per-chunk signatures chained from the **client's** signing key, which can't survive the proxy re-signing the request to the **backend's** credentials. Those are rejected with `NotImplemented` (501) and a message pointing at the default trailing-checksum mode or multipart — an improvement over the previous silent corruption. (The aws-cli/SDK default is unsigned, so this is the uncommon path.)

## ⚠️ Needs runtime validation

The SigV4 header-signed streaming PUT is correct per the spec, but the interaction of a **streamed body + re-signed headers through Cloudflare Workers' `fetch`** and S3's acceptance of it can't be exercised by unit tests. Validate against real S3 on a worker deploy (round-trip a `aws s3 cp` of a small and a multi-MB object) before relying on it.

## Testing

- Unit tests for `aws_chunked::streaming_upload` (unsigned / signed / non-streaming classification).
- Dispatch tests: an unsigned aws-chunked `PUT` resolves to `Forward` carrying the streaming sentinel + a fresh backend `Authorization` + the de-chunk headers; a signed aws-chunked `PUT` is rejected `501`; an unsigned aws-chunked `UploadPart` streams via re-sign.
- Full local CI gauntlet green: `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` (110 passing), `cargo check`, and `cargo check -p multistore-cf-workers --target wasm32-unknown-unknown`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
