### PR TITLE
fix(proxy): forward flexible-checksum headers on multipart ops

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -112,6 +112,12 @@ jobs:
       # here on both preview (PR) and staging deploys, against the stable
       # staging OIDC issuer — see preview.yml / staging.yml.
       FEDERATION_TEST_KEY: ${{ vars.FEDERATION_TEST_KEY }}
+      # Virtual bucket name the multipart write smoke test uploads to
+      # (TestMultipartUpload). Leave the `SMOKE_WRITE_BUCKET` repo/environment
+      # variable unset to skip that test; set it to `smoke-writable` (the bucket
+      # wired in wrangler.deploy.toml) once the backend role has write +
+      # s3:AbortMultipartUpload permissions.
+      SMOKE_WRITE_BUCKET: ${{ vars.SMOKE_WRITE_BUCKET }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,11 @@ on:
         required: false
         type: string
         default: ""
+      smoke_write_bucket:
+        description: "Virtual bucket for the multipart write smoke test; empty skips it"
+        required: false
+        type: string
+        default: ""
       set_secrets:
         description: "Whether to set worker secrets after deploy"
         required: false
@@ -112,12 +117,10 @@ jobs:
       # here on both preview (PR) and staging deploys, against the stable
       # staging OIDC issuer — see preview.yml / staging.yml.
       FEDERATION_TEST_KEY: ${{ vars.FEDERATION_TEST_KEY }}
-      # Virtual bucket name the multipart write smoke test uploads to
-      # (TestMultipartUpload). Leave the `SMOKE_WRITE_BUCKET` repo/environment
-      # variable unset to skip that test; set it to `smoke-writable` (the bucket
-      # wired in wrangler.deploy.toml) once the backend role has write +
-      # s3:AbortMultipartUpload permissions.
-      SMOKE_WRITE_BUCKET: ${{ vars.SMOKE_WRITE_BUCKET }}
+      # Virtual bucket the multipart write smoke test uploads to
+      # (TestMultipartUpload). Set per-caller via the `smoke_write_bucket` input
+      # (preview.yml passes `smoke-writable`); empty -> the test self-skips.
+      SMOKE_WRITE_BUCKET: ${{ inputs.smoke_write_bucket }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -21,6 +21,8 @@ jobs:
       worker_name: multistore-proxy-pr-${{ github.event.pull_request.number }}
       wrangler_config: wrangler.deploy.toml
       environment: preview
+      # Run the real-S3 multipart write smoke test on every preview.
+      smoke_write_bucket: smoke-writable
       # Mint tokens with the STABLE staging issuer rather than this PR's own URL.
       # All deployments share OIDC_PROVIDER_KEY, so a preview can sign assertions
       # whose `iss` is the staging URL; AWS then validates them against the

--- a/crates/core/src/proxy.rs
+++ b/crates/core/src/proxy.rs
@@ -1215,10 +1215,23 @@ where
 
         let mut headers = HeaderMap::new();
 
-        // Forward relevant headers
-        for header_name in &["content-type", "content-length", "content-md5"] {
-            if let Some(val) = pending.original_headers.get(*header_name) {
-                headers.insert(*header_name, val.clone());
+        // Forward entity headers plus the client's flexible-checksum headers.
+        // Modern AWS SDKs/CLI enable CRC32 integrity checksums by default:
+        // CreateMultipartUpload declares the algorithm (`x-amz-checksum-algorithm`)
+        // and CompleteMultipartUpload echoes the per-part / full-object checksums
+        // (`x-amz-checksum-type`, `x-amz-checksum-crc32`, …). Dropping them leaves
+        // the MPU with no checksum context while the parts are stored *with*
+        // checksums, so S3 rejects the completion with `InvalidPart`. This raw
+        // path signs every header present (see `sign_s3_request`), so forwarding
+        // them here is safe — unlike the presigned PutObject path, where S3
+        // rejects unsigned `x-amz-*` headers.
+        for (name, val) in pending.original_headers.iter() {
+            let n = name.as_str();
+            if matches!(n, "content-type" | "content-length" | "content-md5")
+                || n.starts_with("x-amz-checksum")
+                || n == "x-amz-sdk-checksum-algorithm"
+            {
+                headers.insert(name.clone(), val.clone());
             }
         }
         headers.insert(http::header::USER_AGENT, self.user_agent.parse().unwrap());
@@ -2324,6 +2337,129 @@ mod tests {
             assert!(
                 captured.lock().unwrap().is_none(),
                 "backend should be skipped"
+            );
+        });
+    }
+
+    /// Backend that captures the headers forwarded to `send_raw`.
+    #[derive(Clone)]
+    struct CaptureHeadersBackend {
+        captured: Arc<std::sync::Mutex<Option<HeaderMap>>>,
+    }
+
+    impl ProxyBackend for CaptureHeadersBackend {
+        type ResponseBody = ();
+        type Body = ();
+
+        async fn forward(
+            &self,
+            _request: ForwardRequest,
+            _body: (),
+        ) -> Result<ForwardResponse<()>, ProxyError> {
+            unimplemented!()
+        }
+
+        fn create_paginated_store(
+            &self,
+            _config: &BucketConfig,
+        ) -> Result<Box<dyn PaginatedListStore>, ProxyError> {
+            unimplemented!()
+        }
+
+        fn create_signer(&self, config: &BucketConfig) -> Result<Arc<dyn Signer>, ProxyError> {
+            crate::backend::build_signer(config)
+        }
+
+        async fn send_raw(
+            &self,
+            _method: http::Method,
+            _url: String,
+            headers: HeaderMap,
+            _body: Bytes,
+        ) -> Result<RawResponse, ProxyError> {
+            *self.captured.lock().unwrap() = Some(headers);
+            Ok(RawResponse {
+                status: 200,
+                headers: HeaderMap::new(),
+                body: Bytes::new(),
+            })
+        }
+    }
+
+    /// Regression guard: modern AWS CLI/SDK enable CRC32 integrity checksums by
+    /// default, so CompleteMultipartUpload carries `x-amz-checksum-*` headers.
+    /// They must be forwarded to *and signed for* the backend — dropping them
+    /// leaves the upload with no checksum context and S3 fails the completion
+    /// with `InvalidPart`.
+    #[test]
+    fn complete_multipart_forwards_and_signs_checksum_headers() {
+        use crate::types::AuthenticatedIdentity;
+        run(async {
+            let captured = Arc::new(std::sync::Mutex::new(None));
+            let backend = CaptureHeadersBackend {
+                captured: captured.clone(),
+            };
+            let gw = ProxyGateway::new(backend, MockRegistry, MockCreds, None);
+
+            let mut original_headers = HeaderMap::new();
+            original_headers.insert("content-type", "application/xml".parse().unwrap());
+            original_headers.insert("x-amz-checksum-crc32", "AAAAAA==".parse().unwrap());
+            original_headers.insert("x-amz-checksum-type", "FULL_OBJECT".parse().unwrap());
+            original_headers.insert("x-amz-sdk-checksum-algorithm", "CRC32".parse().unwrap());
+            // The client's own credentials must never be forwarded; the proxy
+            // re-signs with the backend creds.
+            original_headers.insert(
+                "authorization",
+                "AWS4-HMAC-SHA256 client-bogus".parse().unwrap(),
+            );
+
+            let pending = PendingRequest {
+                operation: S3Operation::CompleteMultipartUpload {
+                    bucket: "test-bucket".into(),
+                    key: "big.dmg".into(),
+                    upload_id: "upload-1".into(),
+                },
+                bucket_config: test_bucket_config("test-bucket"),
+                original_headers,
+                request_id: "rid".into(),
+                identity: ResolvedIdentity::Authenticated(AuthenticatedIdentity {
+                    principal_name: "tester".into(),
+                    allowed_scopes: vec![],
+                }),
+            };
+
+            let body = Bytes::from_static(
+                br#"<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>"abc"</ETag><ChecksumCRC32>AAAAAA==</ChecksumCRC32></Part></CompleteMultipartUpload>"#,
+            );
+
+            let result = gw.handle_with_body(pending, body).await;
+            assert_eq!(result.status, 200);
+
+            let sent = captured
+                .lock()
+                .unwrap()
+                .clone()
+                .expect("backend was called");
+
+            // 1. The checksum headers reach the backend.
+            assert_eq!(sent.get("x-amz-checksum-crc32").unwrap(), "AAAAAA==");
+            assert_eq!(sent.get("x-amz-checksum-type").unwrap(), "FULL_OBJECT");
+            assert_eq!(sent.get("x-amz-sdk-checksum-algorithm").unwrap(), "CRC32");
+
+            // 2. The client's Authorization is replaced by a fresh proxy signature.
+            let auth = sent.get("authorization").unwrap().to_str().unwrap();
+            assert!(
+                auth.starts_with("AWS4-HMAC-SHA256 Credential="),
+                "expected re-signed Authorization, got: {auth}"
+            );
+
+            // 3. The checksum headers are part of SignedHeaders — without this S3
+            //    ignores them and the completion fails with InvalidPart.
+            assert!(
+                auth.contains("x-amz-checksum-crc32")
+                    && auth.contains("x-amz-checksum-type")
+                    && auth.contains("x-amz-sdk-checksum-algorithm"),
+                "checksum headers missing from SignedHeaders: {auth}"
             );
         });
     }

--- a/examples/cf-workers/wrangler.deploy.toml
+++ b/examples/cf-workers/wrangler.deploy.toml
@@ -62,6 +62,30 @@ bucket_name = "multistore-test-bucket"
 endpoint = "https://s3.us-west-2.amazonaws.com"
 region = "us-west-2"
 
+# Writable bucket for the multipart write smoke test
+# (tests/smoke/test_smoke.py::TestMultipartUpload). The regression it guards —
+# dropped `x-amz-checksum-*` headers causing `InvalidPart` on
+# CompleteMultipartUpload — only reproduces against *real* AWS S3; MinIO accepts
+# the inconsistent upload, so it can't live in the MinIO integration suite.
+#
+# To activate: create the backend bucket, grant the OIDC role s3:PutObject /
+# s3:GetObject / s3:DeleteObject / s3:AbortMultipartUpload / s3:ListBucket on it,
+# and set SMOKE_WRITE_BUCKET=smoke-writable in the smoke-test job's env. Until
+# then the test self-skips. Swap bucket_name/oidc_role_arn for your resources.
+[[vars.PROXY_CONFIG.buckets]]
+allowed_roles = ["github-actions"]
+anonymous_access = false
+backend_type = "s3"
+name = "smoke-writable"
+
+[vars.PROXY_CONFIG.buckets.backend_options]
+auth_type = "oidc"
+oidc_role_arn = "arn:aws:iam::470592060578:role/multistore-github-ci"
+oidc_subject = "multistore"
+bucket_name = "multistore-smoke-writable"
+endpoint = "https://s3.us-west-2.amazonaws.com"
+region = "us-west-2"
+
 [[vars.PROXY_CONFIG.credentials]]
 access_key_id = "AKPROXY00000EXAMPLE"
 secret_access_key = "EXAMPLE000000000000"
@@ -86,6 +110,23 @@ trusted_oidc_issuers = [
 [[vars.PROXY_CONFIG.roles.allowed_scopes]]
 actions = ["get_object", "head_object", "list_bucket"]
 bucket = "cholmes"
+prefixes = []
+
+# Write access for the multipart write smoke test (see the `smoke-writable`
+# bucket above). Multipart needs the create/upload/complete/abort actions.
+[[vars.PROXY_CONFIG.roles.allowed_scopes]]
+actions = [
+  "get_object",
+  "head_object",
+  "put_object",
+  "delete_object",
+  "list_bucket",
+  "create_multipart_upload",
+  "upload_part",
+  "complete_multipart_upload",
+  "abort_multipart_upload",
+]
+bucket = "smoke-writable"
 prefixes = []
 
 [[vars.PROXY_CONFIG.roles]]

--- a/examples/cf-workers/wrangler.deploy.toml
+++ b/examples/cf-workers/wrangler.deploy.toml
@@ -68,21 +68,24 @@ region = "us-west-2"
 # CompleteMultipartUpload — only reproduces against *real* AWS S3; MinIO accepts
 # the inconsistent upload, so it can't live in the MinIO integration suite.
 #
-# To activate: create the backend bucket, grant the OIDC role s3:PutObject /
-# s3:GetObject / s3:DeleteObject / s3:AbortMultipartUpload / s3:ListBucket on it,
-# and set SMOKE_WRITE_BUCKET=smoke-writable in the smoke-test job's env. Until
-# then the test self-skips. Swap bucket_name/oidc_role_arn for your resources.
+# Reuses the federated-test backend bucket + OIDC role, namespaced under a
+# `smoke-writable/` prefix. The role's policy already grants PutObject/GetObject/
+# DeleteObject/ListBucket (which cover Create/Upload/Complete); add
+# `s3:AbortMultipartUpload` so failed uploads clean up instead of orphaning
+# parts. To activate, set SMOKE_WRITE_BUCKET=smoke-writable in the smoke job;
+# until then the test self-skips.
 [[vars.PROXY_CONFIG.buckets]]
 allowed_roles = ["github-actions"]
 anonymous_access = false
 backend_type = "s3"
+backend_prefix = "smoke-writable/"
 name = "smoke-writable"
 
 [vars.PROXY_CONFIG.buckets.backend_options]
 auth_type = "oidc"
 oidc_role_arn = "arn:aws:iam::470592060578:role/multistore-github-ci"
 oidc_subject = "multistore"
-bucket_name = "multistore-smoke-writable"
+bucket_name = "multistore-test-bucket"
 endpoint = "https://s3.us-west-2.amazonaws.com"
 region = "us-west-2"
 

--- a/tests/smoke/test_smoke.py
+++ b/tests/smoke/test_smoke.py
@@ -7,15 +7,35 @@ Requires environment variables:
 """
 
 import os
+import uuid
 import xml.etree.ElementTree as ET
+from io import BytesIO
 
 import boto3
 import pytest
 import requests
+from boto3.s3.transfer import TransferConfig
 from botocore.config import Config
 from botocore.exceptions import ClientError
 
 DEPLOY_URL = os.environ.get("DEPLOY_URL", "http://localhost:8787")
+
+# S3 requires every multipart part except the last to be at least 5 MiB.
+MIB = 1024 * 1024
+
+# A writable bucket on a *real* AWS-S3 backend, addressable by the smoke
+# identity. The integration suite already covers multipart against MinIO, but
+# MinIO does not enforce S3's flexible-checksum validation — the exact gap that
+# let the dropped-`x-amz-checksum-*` bug through — so this regression must run
+# against real S3. The preview's other buckets are read-only (`skip_signature`)
+# mirrors, so this is opt-in: set SMOKE_WRITE_BUCKET to the writable bucket's
+# virtual name (see `smoke-writable` in examples/cf-workers/wrangler.deploy.toml).
+WRITE_BUCKET = os.environ.get("SMOKE_WRITE_BUCKET")
+
+requires_write_bucket = pytest.mark.skipif(
+    not WRITE_BUCKET,
+    reason="SMOKE_WRITE_BUCKET not set (no writable real-S3 bucket configured)",
+)
 
 
 def assume_role(role_arn: str, oidc_token: str) -> dict:
@@ -229,3 +249,46 @@ class TestRangeRequests:
                 f"CF may be serving a cached full-body response."
             )
             assert resp.headers.get("content-range") is not None
+
+
+@requires_oidc
+@requires_write_bucket
+class TestMultipartUpload:
+    """Multipart upload against a real S3 backend.
+
+    Regression guard for the dropped flexible-checksum headers bug: modern AWS
+    CLI/SDK enable CRC32 integrity checksums by default, so a multipart upload
+    sends a per-part checksum on each UploadPart and echoes them on
+    CompleteMultipartUpload. If the proxy drops the `x-amz-checksum-*` headers,
+    the upload is initialized with no checksum context while the parts carry
+    checksums, and S3 rejects completion with `InvalidPart`. Checksums are
+    forced on here (`ChecksumAlgorithm=CRC32`) so the path is exercised
+    regardless of the client's botocore default.
+
+    This is what `aws s3 cp` of a large file does and what originally surfaced
+    the bug; MinIO (the integration backend) does not reproduce it.
+    """
+
+    def test_multipart_roundtrip_with_checksums(self, actions_credentials):
+        client = s3_client(actions_credentials)
+        key = f"smoke-multipart-{uuid.uuid4()}.bin"
+        # 6 MiB → two parts (5 MiB + 1 MiB) at a 5 MiB chunk size.
+        body = bytes(i % 251 for i in range(6 * MIB))
+        config = TransferConfig(
+            multipart_threshold=5 * MIB,
+            multipart_chunksize=5 * MIB,
+            max_concurrency=1,
+            use_threads=False,
+        )
+        try:
+            client.upload_fileobj(
+                BytesIO(body),
+                WRITE_BUCKET,
+                key,
+                Config=config,
+                ExtraArgs={"ChecksumAlgorithm": "CRC32"},
+            )
+            resp = client.get_object(Bucket=WRITE_BUCKET, Key=key)
+            assert resp["Body"].read() == body
+        finally:
+            client.delete_object(Bucket=WRITE_BUCKET, Key=key)


### PR DESCRIPTION
## Problem

Large-file uploads via `aws s3 cp` (AWS CLI v2.27.34) through the proxy fail at `CompleteMultipartUpload`:

```
An error occurred (InvalidPart) when calling the CompleteMultipartUpload operation:
One or more of the specified parts could not be found. The part may not have been
uploaded, or the specified entity tag may not match the part's entity tag.
```

Parts all upload with `200`; only the completion fails. Setting `AWS_REQUEST_CHECKSUM_CALCULATION=when_required` (disables the CLI's default CRC32 checksums) makes it succeed — pinpointing the trigger as AWS's **default data-integrity checksums** (CRC32), on by default since AWS CLI v2 ~2.23 / recent botocore.

## Root cause

`execute_multipart` (the raw-signed path for Create/Complete/Abort) forwarded only `["content-type", "content-length", "content-md5"]` and **dropped every `x-amz-checksum-*` header**:

- `CreateMultipartUpload`'s `x-amz-checksum-algorithm` was dropped → S3 initialized the MPU with **no checksum context**.
- Parts uploaded fine *with* CRC32 (the streaming re-sign path in `build_streaming_forward` forwards `x-amz-trailer`).
- `CompleteMultipartUpload` sends per-part `<ChecksumCRC32>` in the body plus `x-amz-checksum-type` — the headers were dropped → S3 saw an inconsistent MPU → `InvalidPart`.

## Fix

Forward the client's `x-amz-checksum-*` and `x-amz-sdk-checksum-algorithm` headers in `execute_multipart`. This path signs every header present (`sign_s3_request`), so the forwarded headers are covered by the signature — unlike the presigned `PutObject` path, where unsigned `x-amz-*` headers are rejected. Because Create, Complete, and plain (non-chunked) `UploadPart` all flow through this one function, the single change fixes the whole lifecycle.

## Test

A functional regression test (`complete_multipart_forwards_and_signs_checksum_headers`) drives the public `handle_with_body` with a `CompleteMultipartUpload` and a header-capturing backend, asserting the checksum headers both **reach** the backend and appear in the **re-signed `SignedHeaders`**. Verified it fails on the pre-fix code (the `x-amz-checksum-crc32` header is absent) and passes after. Full core suite: 112 passing.

## Notes

- Stacked on #92 (`fix/decode-aws-chunked-writes`) — that branch adds the streaming part path this fix depends on; `main` has no streaming path, so the bug isn't reachable in this form there.
- **Recommend an end-to-end check against real S3** before relying on this (verify the object round-trips and `aws s3api head-object` reports the expected checksum). The `AWS_REQUEST_CHECKSUM_CALCULATION` evidence is suggestive but also reroutes the part path, so it isn't fully isolating on its own.
- **Out of scope / follow-up:** the CLI's auto-`AbortMultipartUpload` returns `403` (backend role / token scope likely missing `s3:AbortMultipartUpload` / `abort_multipart_upload`) — a separate authorization gap, not caused by the header drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)