### PR TITLE
fix(cf-workers): bypass Cloudflare cache for HEAD subrequests

### DIFF
--- a/crates/cf-workers/src/backend.rs
+++ b/crates/cf-workers/src/backend.rs
@@ -45,8 +45,11 @@ impl ProxyBackend for WorkerBackend {
         init.set_method(request.method.as_str());
         init.set_headers(&WsHeaders::from(&request.headers).into_inner().into());
 
-        // Bypass Cloudflare's subrequest cache for Range requests.
-        if request.headers.contains_key(http::header::RANGE) {
+        // Bypass Cloudflare's subrequest cache for reads where leaving it on
+        // would break the request (HEAD rewritten to GET on cacheable-extension
+        // URLs, or Range poisoning the full-object cache). See
+        // `ForwardRequest::should_bypass_cache`.
+        if request.should_bypass_cache() {
             init.set_cache(web_sys::RequestCache::NoStore);
         }
 

--- a/crates/core/src/route_handler.rs
+++ b/crates/core/src/route_handler.rs
@@ -63,6 +63,27 @@ pub struct ForwardRequest {
     pub request_id: String,
 }
 
+impl ForwardRequest {
+    /// Whether the runtime must skip any shared/CDN cache when executing this
+    /// forward (e.g. set Cloudflare's `RequestCache::NoStore` on the subrequest).
+    ///
+    /// Two request shapes are unsafe against a full-object `GET` cache:
+    ///
+    /// * **`HEAD`** — a CDN that only caches `GET` (e.g. Cloudflare) may rewrite
+    ///   an outbound `HEAD` on a cacheable-looking URL (a key with a static-asset
+    ///   extension such as `.dmg`/`.tif`/`.zip`/`.gif`) into a `GET`. Because the
+    ///   backend URL is presigned for the *original* method, the rewritten `GET`
+    ///   fails SigV4 and the store returns `403 SignatureDoesNotMatch`.
+    /// * **`Range`** — a partial (`206`) response must never be written to or
+    ///   served from the full-object cache entry.
+    ///
+    /// Plain full-object `GET` is intentionally left cacheable so the edge can
+    /// serve public objects.
+    pub fn should_bypass_cache(&self) -> bool {
+        self.method == Method::HEAD || self.headers.contains_key(http::header::RANGE)
+    }
+}
+
 /// The result of handling a proxy request.
 pub struct ProxyResult {
     /// HTTP status code for the response.
@@ -302,6 +323,34 @@ pub trait RouteHandler: MaybeSend + MaybeSync {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn forward(method: Method, range: Option<&str>) -> ForwardRequest {
+        let mut headers = http::HeaderMap::new();
+        if let Some(r) = range {
+            headers.insert(http::header::RANGE, r.parse().unwrap());
+        }
+        ForwardRequest {
+            method,
+            url: "https://example.com/bucket/object".parse().unwrap(),
+            headers,
+            request_id: "test".into(),
+        }
+    }
+
+    #[test]
+    fn should_bypass_cache_predicate() {
+        // HEAD must bypass: a GET-only CDN rewrites it to GET on a
+        // cacheable-extension URL, and the presigned (HEAD-signed) backend URL
+        // then fails SigV4 -> 403 SignatureDoesNotMatch.
+        assert!(forward(Method::HEAD, None).should_bypass_cache());
+        // Range (any method) must bypass: don't serve/write partials to the
+        // full-object cache entry.
+        assert!(forward(Method::GET, Some("bytes=0-0")).should_bypass_cache());
+        assert!(forward(Method::HEAD, Some("bytes=0-1023")).should_bypass_cache());
+        // Full-object GET stays cacheable; writes don't match.
+        assert!(!forward(Method::GET, None).should_bypass_cache());
+        assert!(!forward(Method::PUT, None).should_bypass_cache());
+    }
 
     #[test]
     fn test_blocks_hop_by_hop_headers() {


### PR DESCRIPTION
## Problem

The Cloudflare Workers backend forwards object reads to the upstream store via a **presigned URL signed for the request's HTTP method**. Cloudflare's subrequest cache only operates on `GET`, and for a URL it classifies as a cacheable static asset (a key whose extension is in CF's default list — `.dmg`, `.tif`, `.zip`, `.gif`, `.pdf`, `.csv`, `.js`, …) it **rewrites an outbound `HEAD` into a `GET`**. That rewritten `GET` then fails SigV4 against the `HEAD`-signed presigned URL, so the store returns **`403 SignatureDoesNotMatch`**, which the Worker relays.

Symptom: a `HEAD` on a key with a cacheable extension (e.g. `foo.dmg`) returns 403, while a `HEAD` on the same object **without** an extension (`foo`) and **all** `GET`s succeed. Reproduced against AWS S3; a direct-to-AWS `HEAD` returns 200 (the object is healthy), confirming the rewrite happens at the Cloudflare edge.

### Evidence
- The 403 carries `x-amz-request-id` + `Content-Type: application/xml` → AWS produced it, and it received a **GET** (XML error bodies come from GET, not HEAD).
- The failing extension set is **exactly** Cloudflare's default static-cacheable list (`.csv` fails; `.txt`/`.json`/`.html`/`.xml`/no-extension pass).
- `CF-Cache-Status: BYPASS` on the failing path vs `DYNAMIC` on the passing path.

## Root cause

`WorkerBackend::forward` already bypassed the cache (`RequestCache::NoStore`) — but only when a `Range` header was present. `HEAD` requests carry no `Range`, so they fell through to the cached path and got rewritten.

## Fix

Add `ForwardRequest::should_bypass_cache()` (true for `HEAD` or any `Range` request) and gate the existing `NoStore` on it. Plain full-object `GET` stays cacheable so the edge can still serve public objects.

## Tests

`should_bypass_cache_predicate` (in `core`, runs under host `cargo test`) covers HEAD, ranged GET/HEAD, plain GET, and PUT. The predicate lives on `ForwardRequest` in `core` rather than inline in `cf-workers` because `cf-workers` is wasm-only and excluded from the host `cargo test`/`cargo check` jobs.

## Verification
- `cargo test -p multistore` — predicate tests pass.
- `cargo check -p multistore-cf-workers --target wasm32-unknown-unknown` — compiles.
- `cargo fmt --check`, `cargo clippy -p multistore -- -D warnings` — clean.
- Post-deploy check: `HEAD` on a `.dmg`/`.gif` key returns 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
