### PR TITLE
test(smoke): regression for HEAD on cacheable-extension keys

### DIFF
--- a/tests/smoke/test_smoke.py
+++ b/tests/smoke/test_smoke.py
@@ -292,3 +292,34 @@ class TestMultipartUpload:
             assert resp["Body"].read() == body
         finally:
             client.delete_object(Bucket=WRITE_BUCKET, Key=key)
+
+
+@requires_write_bucket
+class TestHeadOnCacheableExtension:
+    """Regression guard for HEAD on a key with a cacheable static-asset extension.
+
+    Cloudflare's edge cache only operates on GET; for a URL it treats as a
+    cacheable static asset (a key whose extension is in CF's default list, e.g.
+    `.tif`/`.dmg`/`.zip`) it rewrites an outbound HEAD into a GET. Because the
+    proxy forwards each read via a presigned URL signed for the *original*
+    method, the rewritten GET fails SigV4 and S3 returns
+    `403 SignatureDoesNotMatch`. The proxy must mark HEAD subrequests
+    `RequestCache::NoStore` so the edge leaves the method alone.
+
+    Only reproduces against the real Cloudflare edge — MinIO (the integration
+    backend) has no edge cache — so this lives in the smoke suite. The `.tif`
+    extension is what makes the URL look cacheable; a key with no extension was
+    never affected.
+    """
+
+    def test_head_object_with_cacheable_extension(self, actions_credentials):
+        client = s3_client(actions_credentials)
+        key = f"smoke-head-{uuid.uuid4()}.tif"
+        try:
+            client.put_object(Bucket=WRITE_BUCKET, Key=key, Body=b"regression")
+            # Before the fix, Cloudflare rewrote this HEAD to GET and S3
+            # returned 403 SignatureDoesNotMatch (boto3 would raise here).
+            resp = client.head_object(Bucket=WRITE_BUCKET, Key=key)
+            assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+        finally:
+            client.delete_object(Bucket=WRITE_BUCKET, Key=key)


### PR DESCRIPTION
## What

Adds a smoke-suite regression test for the Cloudflare HEAD cache-rewrite bug fixed in #95.

## Why the smoke suite (not integration)

The bug is a **Cloudflare edge** behavior: for a URL whose extension is in CF's cacheable static-asset set (`.tif`, `.dmg`, `.zip`, …), the edge rewrites the Worker's outbound `HEAD` into a `GET`. Because the proxy forwards reads via a presigned URL signed for the *original* method, that rewritten `GET` fails SigV4 and S3 returns `403 SignatureDoesNotMatch`. The integration suite runs against **MinIO**, which has no edge cache, so it cannot reproduce this — only the smoke suite (deployed preview = real Cloudflare + real S3) can.

## The test

`TestHeadOnCacheableExtension` PUTs a `.tif` object to the writable real-S3 bucket and asserts `HEAD` returns 200 (before #95 this returned 403). Mirrors the existing `TestMultipartUpload` checksum regression: gated on `SMOKE_WRITE_BUCKET`, uses the `actions_credentials` role, cleans up after itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
