### PR TITLE
fix: bound buffered-op body size and fail closed on classifier over-match

### DIFF
--- a/crates/cf-workers/src/backend.rs
+++ b/crates/cf-workers/src/backend.rs
@@ -84,8 +84,9 @@ impl ProxyBackend for WorkerBackend {
             init.set_cache(web_sys::RequestCache::NoStore);
         }
 
-        // For PUT: stream the body through (zero-copy). A bare `ReadableStream`
-        // body makes the Workers runtime send the subrequest with
+        // For PUT: stream the body through without buffering it in WASM memory.
+        // A bare `ReadableStream` body makes the Workers runtime send the
+        // subrequest with
         // `Transfer-Encoding: chunked` and *drop* `Content-Length` — which S3
         // rejects for a non-aws-chunked payload (it can't size the object/part),
         // leaving the subrequest hung until the whole body streams through.
@@ -103,7 +104,12 @@ impl ProxyBackend for WorkerBackend {
                         let transform: &web_sys::TransformStream = fls.as_ref();
                         // The outbound fetch consuming `readable` pulls the body
                         // through the transform; the pipe is driven by that
-                        // backpressure, so it streams rather than buffers.
+                        // backpressure, so it streams rather than buffers. The
+                        // returned promise is intentionally dropped: a pipe
+                        // failure (e.g. the client sending fewer/more bytes than
+                        // Content-Length, which errors the FixedLengthStream)
+                        // also errors `readable`, so the awaited outbound fetch
+                        // fails and the error surfaces there.
                         let _ = stream.pipe_to(&transform.writable());
                         init.set_body(&transform.readable());
                     }

--- a/crates/core/src/proxy.rs
+++ b/crates/core/src/proxy.rs
@@ -452,6 +452,16 @@ where
         let mut body = Some(body);
         let mut prebuffered: Option<Bytes> = None;
         if self.op_needs_buffered_body(req) {
+            // Bound the declared body size before reading it. This eager read is
+            // ahead of dispatch's own `check_upload_size`, so without this guard
+            // an oversized buffered op (e.g. a batch `DeleteObjects`) would be
+            // fully materialized into memory before being rejected. Header-only,
+            // no I/O.
+            if let Err(e) = self.check_upload_size(req.headers) {
+                let mut r = error_response(&e, req.path, "", self.debug_errors);
+                self.maybe_inject_server_timing(&mut r.headers, total_start, None, None);
+                return GatewayResponse::Response(r);
+            }
             match collect_body(body.take().expect("body present")).await {
                 Ok(bytes) => prebuffered = Some(bytes),
                 Err(e) => {
@@ -490,7 +500,25 @@ where
             }
             HandlerAction::Forward(fwd) => {
                 let backend_start = chrono::Utc::now();
-                let fwd_body = body.take().expect("streaming op retains its body");
+                // `body` is consumed only here (streaming/forward ops). If the
+                // eager pre-read already took it, `op_needs_buffered_body`
+                // over-matched an op that dispatched to Forward — fail closed
+                // rather than panic on the missing body.
+                let Some(fwd_body) = body.take() else {
+                    let mut r = error_response(
+                        &ProxyError::Internal("request body already consumed".into()),
+                        req.path,
+                        &metadata.request_id,
+                        self.debug_errors,
+                    );
+                    self.maybe_inject_server_timing(
+                        &mut r.headers,
+                        total_start,
+                        Some(dispatch_start),
+                        None,
+                    );
+                    return GatewayResponse::Response(r);
+                };
                 match self.backend.forward(fwd, fwd_body).await {
                     Ok(mut resp) => {
                         resp.headers = filter_response_headers(&resp.headers);

--- a/crates/core/src/proxy.rs
+++ b/crates/core/src/proxy.rs
@@ -337,6 +337,22 @@ where
         )
     }
 
+    /// Build an error [`GatewayResponse`] with its `Server-Timing` header
+    /// stamped. Used by the early returns in `handle_request` (body too large,
+    /// body read failure, body already consumed) that bail before dispatch.
+    fn early_error(
+        &self,
+        error: &ProxyError,
+        path: &str,
+        request_id: &str,
+        total_start: chrono::DateTime<chrono::Utc>,
+        dispatch_start: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> GatewayResponse<B::ResponseBody> {
+        let mut r = error_response(error, path, request_id, self.debug_errors);
+        self.maybe_inject_server_timing(&mut r.headers, total_start, dispatch_start, None);
+        GatewayResponse::Response(r)
+    }
+
     /// Inject a `Server-Timing` header into the response headers if enabled.
     fn maybe_inject_server_timing(
         &self,
@@ -458,22 +474,19 @@ where
             // fully materialized into memory before being rejected. Header-only,
             // no I/O.
             if let Err(e) = self.check_upload_size(req.headers) {
-                let mut r = error_response(&e, req.path, "", self.debug_errors);
-                self.maybe_inject_server_timing(&mut r.headers, total_start, None, None);
-                return GatewayResponse::Response(r);
+                return self.early_error(&e, req.path, "", total_start, None);
             }
             match collect_body(body.take().expect("body present")).await {
                 Ok(bytes) => prebuffered = Some(bytes),
                 Err(e) => {
                     tracing::error!(error = %e, "failed to read request body");
-                    let mut r = error_response(
+                    return self.early_error(
                         &ProxyError::Internal("failed to read request body".into()),
                         req.path,
                         "",
-                        self.debug_errors,
+                        total_start,
+                        None,
                     );
-                    self.maybe_inject_server_timing(&mut r.headers, total_start, None, None);
-                    return GatewayResponse::Response(r);
                 }
             }
         }
@@ -505,19 +518,13 @@ where
                 // over-matched an op that dispatched to Forward — fail closed
                 // rather than panic on the missing body.
                 let Some(fwd_body) = body.take() else {
-                    let mut r = error_response(
+                    return self.early_error(
                         &ProxyError::Internal("request body already consumed".into()),
                         req.path,
                         &metadata.request_id,
-                        self.debug_errors,
-                    );
-                    self.maybe_inject_server_timing(
-                        &mut r.headers,
                         total_start,
                         Some(dispatch_start),
-                        None,
                     );
-                    return GatewayResponse::Response(r);
                 };
                 match self.backend.forward(fwd, fwd_body).await {
                     Ok(mut resp) => {


### PR DESCRIPTION
Follow-ups to #100 (merged as `60b4278`), from a code review of that change. Two small correctness fixes plus comment accuracy.

## 1. Bound the buffered-op body before the eager pre-read

#100 moved the body read for buffered ops (multipart control + batch delete) to the top of `handle_request`, ahead of `resolve` — but that's also ahead of `dispatch_operation`'s `check_upload_size`. So an oversized declared `Content-Length` was fully materialized into memory *before* being rejected, and the three multipart-control ops (which never call `check_upload_size`) had no size bound at all. Pre-#100, the header-only guard fired before any bytes were read.

This restores that ordering: run the header-only `check_upload_size` in the `op_needs_buffered_body` branch, before `collect_body`.

## 2. Fail closed instead of panic on classifier over-match

`op_needs_buffered_body` must mirror the `NeedsBody` arms of `dispatch_operation`. The under-match direction already fails closed (a `NeedsBody` op the classifier missed returns a clean 500). The over-match direction did not: if a buffered-classified op ever dispatched to `Forward`, the body was already taken by the pre-read and `body.take().expect("streaming op retains its body")` would **panic** (worse on Workers than a 500). The `Forward` arm now returns a 500 instead, matching the other direction.

Not reachable with today's op set, but it's latent fragility on the same hand-maintained invariant.

## 3. Comment accuracy

- The `FixedLengthStream` PUT branch streams but is **not** zero-copy (chunks cross the transform boundary); only the raw-stream branch is.
- Documented that the dropped `pipe_to` promise isn't a silent failure — a pipe error also errors `readable`, so the awaited outbound fetch fails and surfaces it.

## Tests

Core suite (115) passes. cf-workers is wasm-checked. (Note for maintainers: cf-workers has no executable test coverage — `worker::Fetch`'s future is `!Send` on the host target so the crate doesn't compile natively, and CI only `cargo check`s it on wasm32. `fixed_body_length` would be a clean unit test if that's ever resolved.)

## Deliberately out of scope (review noted, not done here)

- **Parse once / drop the classifier:** split `resolve_request_with_metadata` into a sync parse phase + async authorize phase and derive the buffer/stream decision from the single parsed `S3Operation`. Removes the double-parse, the `op_needs_buffered_body` classifier, the drift hazard, and the need for fix #2 entirely. Larger refactor — separate PR.
- **411 for a plain PUT with no `Content-Length`** (currently falls back to the chunked path that hangs).
- Plain `PutObject` drops `x-amz-checksum-*` while plain `UploadPart` now preserves them — worth reconciling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)