### PR TITLE
fix(cf-workers): sign the encoded request path; harden the signing-path contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "multistore"
-version = "0.5.1"
+version = "0.6.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-cf-workers"
-version = "0.5.1"
+version = "0.6.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-cf-workers-example"
-version = "0.5.1"
+version = "0.6.2"
 dependencies = [
  "bytes",
  "console_error_panic_hook",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-lambda"
-version = "0.5.1"
+version = "0.6.2"
 dependencies = [
  "bytes",
  "http",
@@ -1214,7 +1214,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-metering"
-version = "0.5.1"
+version = "0.6.2"
 dependencies = [
  "bytes",
  "futures",
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-oidc-provider"
-version = "0.5.1"
+version = "0.6.2"
 dependencies = [
  "base64",
  "chrono",
@@ -1246,7 +1246,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-path-mapping"
-version = "0.5.1"
+version = "0.6.2"
 dependencies = [
  "multistore",
  "percent-encoding",
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-server"
-version = "0.5.1"
+version = "0.6.2"
 dependencies = [
  "axum",
  "bytes",
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-static-config"
-version = "0.5.1"
+version = "0.6.2"
 dependencies = [
  "chrono",
  "multistore",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-sts"
-version = "0.5.1"
+version = "0.6.2"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/crates/cf-workers/src/request.rs
+++ b/crates/cf-workers/src/request.rs
@@ -27,8 +27,21 @@ use multistore::route_handler::RequestInfo;
 pub struct RequestParts {
     /// The HTTP method.
     pub method: Method,
-    /// The URL path (e.g. `"/bucket/key"`).
+    /// The percent-**decoded** URL path (e.g. `"/bucket/my key"`).
+    ///
+    /// Decoded for S3 operation parsing and bucket/key routing. **Do not** use
+    /// this for SigV4 verification: the canonical URI must be the encoded form
+    /// the client signed, so use [`signing_path`](Self::signing_path) instead.
     pub path: String,
+    /// The raw, percent-**encoded** URL path exactly as it arrived on the wire
+    /// (e.g. `"/bucket/my%20key"`).
+    ///
+    /// This is the form the client signs, so it is what SigV4 verification must
+    /// canonicalize over. [`as_request_info`](Self::as_request_info) wires it
+    /// into [`RequestInfo`]'s signing path automatically. Integrators that
+    /// rewrite paths before dispatch (e.g. path-mapping) must still sign against
+    /// this encoded path — never the decoded [`path`](Self::path).
+    pub signing_path: String,
     /// The raw query string, if present.
     pub query: Option<String>,
     /// The HTTP request headers.
@@ -51,6 +64,10 @@ impl RequestParts {
 
         let uri: Uri = req.url().parse().map_err(|e| format!("invalid URL: {e}"))?;
 
+        // `uri.path()` is the raw, percent-encoded path. Keep it verbatim for
+        // SigV4 signing (the client signs the encoded form), and separately
+        // decode it for operation parsing and bucket/key routing.
+        let signing_path = uri.path().to_string();
         let path = percent_encoding::percent_decode_str(uri.path())
             .decode_utf8_lossy()
             .to_string();
@@ -61,6 +78,7 @@ impl RequestParts {
             Self {
                 method,
                 path,
+                signing_path,
                 query,
                 headers,
             },
@@ -69,6 +87,12 @@ impl RequestParts {
     }
 
     /// Borrow this struct as a [`RequestInfo`] for gateway dispatch.
+    ///
+    /// Sets the signing path to the raw, percent-encoded
+    /// [`signing_path`](Self::signing_path) so SigV4 verification canonicalizes
+    /// over the path the client actually signed. Without this, a key containing
+    /// a character the client escapes — e.g. a space → `%20` — would be verified
+    /// against the decoded path and fail with `SignatureDoesNotMatch`.
     pub fn as_request_info(&self) -> RequestInfo<'_> {
         RequestInfo::new(
             &self.method,
@@ -77,5 +101,6 @@ impl RequestParts {
             &self.headers,
             None,
         )
+        .with_signing_path(&self.signing_path)
     }
 }

--- a/crates/core/src/auth/sigv4.rs
+++ b/crates/core/src/auth/sigv4.rs
@@ -144,6 +144,19 @@ pub fn verify_sigv4_signature(
             region = %auth.region,
             "SigV4 signature mismatch"
         );
+        // A literal space in the canonical URI is never valid — clients sign the
+        // percent-encoded path (`%20`). Its presence means a decoded path was
+        // handed to signing; point the integrator straight at the cause. This
+        // catches the common case only; other unencoded characters won't trip
+        // it, but the debug canonical_request below still shows them.
+        if uri_path.contains(' ') {
+            tracing::warn!(
+                "the signing path contains a literal space — SigV4 requires the \
+                 percent-encoded path (`%20`). A decoded path (e.g. \
+                 `RequestParts::path`) was likely used; pass the encoded \
+                 `signing_path` instead."
+            );
+        }
         tracing::debug!(
             canonical_request = %canonical_request,
             string_to_sign = %string_to_sign,

--- a/crates/core/src/auth/sigv4.rs
+++ b/crates/core/src/auth/sigv4.rs
@@ -144,18 +144,10 @@ pub fn verify_sigv4_signature(
             region = %auth.region,
             "SigV4 signature mismatch"
         );
-        // A literal space in the canonical URI is never valid — clients sign the
-        // percent-encoded path (`%20`). Its presence means a decoded path was
-        // handed to signing; point the integrator straight at the cause. This
-        // catches the common case only; other unencoded characters won't trip
-        // it, but the debug canonical_request below still shows them.
+        // A literal space in the canonical URI means a decoded path reached
+        // signing (clients sign `%20`) — the usual cause of this mismatch.
         if uri_path.contains(' ') {
-            tracing::warn!(
-                "the signing path contains a literal space — SigV4 requires the \
-                 percent-encoded path (`%20`). A decoded path (e.g. \
-                 `RequestParts::path`) was likely used; pass the encoded \
-                 `signing_path` instead."
-            );
+            tracing::warn!("signing path has a literal space; pass the percent-encoded path, not the decoded one");
         }
         tracing::debug!(
             canonical_request = %canonical_request,

--- a/crates/core/src/auth/tests.rs
+++ b/crates/core/src/auth/tests.rs
@@ -116,8 +116,12 @@ fn sign_request(
     )
 }
 
-/// Build headers and auth for a simple GET request.
-fn make_signed_headers(access_key_id: &str, secret_access_key: &str) -> HeaderMap {
+/// Build headers with a valid SigV4 GET signature over `signing_path`.
+fn signed_get_headers(
+    signing_path: &str,
+    access_key_id: &str,
+    secret_access_key: &str,
+) -> HeaderMap {
     let date_stamp = "20240101";
     let amz_date = "20240101T000000Z";
     let region = "us-east-1";
@@ -130,7 +134,7 @@ fn make_signed_headers(access_key_id: &str, secret_access_key: &str) -> HeaderMa
 
     let auth = sign_request(
         &http::Method::GET,
-        "/test-bucket/key.txt",
+        signing_path,
         "",
         &headers,
         access_key_id,
@@ -143,6 +147,11 @@ fn make_signed_headers(access_key_id: &str, secret_access_key: &str) -> HeaderMa
     );
     headers.insert("authorization", auth.parse().unwrap());
     headers
+}
+
+/// Build headers and auth for a simple GET request.
+fn make_signed_headers(access_key_id: &str, secret_access_key: &str) -> HeaderMap {
+    signed_get_headers("/test-bucket/key.txt", access_key_id, secret_access_key)
 }
 
 // ── Tests ─────────────────────────────────────────────────────────
@@ -338,33 +347,10 @@ fn encoded_signing_path_verifies() {
     run(async {
         let secret = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
         let config = MockConfig::with_credential(secret);
+        // The client signs the percent-encoded path (a space → `%20`); verifying
+        // against that same encoded path succeeds.
+        let headers = signed_get_headers("/test-bucket/foo%20bar", "AKIAIOSFODNN7EXAMPLE", secret);
 
-        let date_stamp = "20240101";
-        let amz_date = "20240101T000000Z";
-        let payload_hash = "UNSIGNED-PAYLOAD";
-
-        let mut headers = HeaderMap::new();
-        headers.insert("host", "s3.example.com".parse().unwrap());
-        headers.insert("x-amz-date", amz_date.parse().unwrap());
-        headers.insert("x-amz-content-sha256", payload_hash.parse().unwrap());
-
-        // The client signs the percent-encoded path (a space → `%20`).
-        let auth = sign_request(
-            &http::Method::GET,
-            "/test-bucket/foo%20bar",
-            "",
-            &headers,
-            "AKIAIOSFODNN7EXAMPLE",
-            secret,
-            date_stamp,
-            amz_date,
-            "us-east-1",
-            &["host", "x-amz-content-sha256", "x-amz-date"],
-            payload_hash,
-        );
-        headers.insert("authorization", auth.parse().unwrap());
-
-        // Verifying against that same encoded path succeeds.
         let identity = resolve_identity(
             &http::Method::GET,
             "/test-bucket/foo%20bar",
@@ -386,36 +372,13 @@ fn encoded_signing_path_verifies() {
 #[test]
 fn decoded_signing_path_is_rejected() {
     // Regression: the client signs `/test-bucket/foo%20bar`, but verifying
-    // against the *decoded* `/test-bucket/foo bar` produces a different
-    // canonical URI, so it must fail. This is the exact shape of the bug that
-    // broke uploads of keys containing spaces — a decoded path reached signing.
+    // against the *decoded* `/test-bucket/foo bar` produces a different canonical
+    // URI, so it must fail — the exact shape of the bug that broke uploads of
+    // keys containing spaces (a decoded path reached signing).
     run(async {
         let secret = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
         let config = MockConfig::with_credential(secret);
-
-        let date_stamp = "20240101";
-        let amz_date = "20240101T000000Z";
-        let payload_hash = "UNSIGNED-PAYLOAD";
-
-        let mut headers = HeaderMap::new();
-        headers.insert("host", "s3.example.com".parse().unwrap());
-        headers.insert("x-amz-date", amz_date.parse().unwrap());
-        headers.insert("x-amz-content-sha256", payload_hash.parse().unwrap());
-
-        let auth = sign_request(
-            &http::Method::GET,
-            "/test-bucket/foo%20bar",
-            "",
-            &headers,
-            "AKIAIOSFODNN7EXAMPLE",
-            secret,
-            date_stamp,
-            amz_date,
-            "us-east-1",
-            &["host", "x-amz-content-sha256", "x-amz-date"],
-            payload_hash,
-        );
-        headers.insert("authorization", auth.parse().unwrap());
+        let headers = signed_get_headers("/test-bucket/foo%20bar", "AKIAIOSFODNN7EXAMPLE", secret);
 
         let err = resolve_identity(
             &http::Method::GET,

--- a/crates/core/src/auth/tests.rs
+++ b/crates/core/src/auth/tests.rs
@@ -334,6 +334,109 @@ fn unknown_access_key_is_rejected() {
 }
 
 #[test]
+fn encoded_signing_path_verifies() {
+    run(async {
+        let secret = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+        let config = MockConfig::with_credential(secret);
+
+        let date_stamp = "20240101";
+        let amz_date = "20240101T000000Z";
+        let payload_hash = "UNSIGNED-PAYLOAD";
+
+        let mut headers = HeaderMap::new();
+        headers.insert("host", "s3.example.com".parse().unwrap());
+        headers.insert("x-amz-date", amz_date.parse().unwrap());
+        headers.insert("x-amz-content-sha256", payload_hash.parse().unwrap());
+
+        // The client signs the percent-encoded path (a space → `%20`).
+        let auth = sign_request(
+            &http::Method::GET,
+            "/test-bucket/foo%20bar",
+            "",
+            &headers,
+            "AKIAIOSFODNN7EXAMPLE",
+            secret,
+            date_stamp,
+            amz_date,
+            "us-east-1",
+            &["host", "x-amz-content-sha256", "x-amz-date"],
+            payload_hash,
+        );
+        headers.insert("authorization", auth.parse().unwrap());
+
+        // Verifying against that same encoded path succeeds.
+        let identity = resolve_identity(
+            &http::Method::GET,
+            "/test-bucket/foo%20bar",
+            "",
+            &headers,
+            &config,
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(
+            identity,
+            crate::types::ResolvedIdentity::Authenticated(_)
+        ));
+    });
+}
+
+#[test]
+fn decoded_signing_path_is_rejected() {
+    // Regression: the client signs `/test-bucket/foo%20bar`, but verifying
+    // against the *decoded* `/test-bucket/foo bar` produces a different
+    // canonical URI, so it must fail. This is the exact shape of the bug that
+    // broke uploads of keys containing spaces — a decoded path reached signing.
+    run(async {
+        let secret = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+        let config = MockConfig::with_credential(secret);
+
+        let date_stamp = "20240101";
+        let amz_date = "20240101T000000Z";
+        let payload_hash = "UNSIGNED-PAYLOAD";
+
+        let mut headers = HeaderMap::new();
+        headers.insert("host", "s3.example.com".parse().unwrap());
+        headers.insert("x-amz-date", amz_date.parse().unwrap());
+        headers.insert("x-amz-content-sha256", payload_hash.parse().unwrap());
+
+        let auth = sign_request(
+            &http::Method::GET,
+            "/test-bucket/foo%20bar",
+            "",
+            &headers,
+            "AKIAIOSFODNN7EXAMPLE",
+            secret,
+            date_stamp,
+            amz_date,
+            "us-east-1",
+            &["host", "x-amz-content-sha256", "x-amz-date"],
+            payload_hash,
+        );
+        headers.insert("authorization", auth.parse().unwrap());
+
+        let err = resolve_identity(
+            &http::Method::GET,
+            "/test-bucket/foo bar", // decoded — wrong for signing
+            "",
+            &headers,
+            &config,
+            None,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, ProxyError::SignatureDoesNotMatch),
+            "decoded signing path must not verify, got: {:?}",
+            err
+        );
+    });
+}
+
+#[test]
 fn temporary_credential_wrong_session_token_is_rejected() {
     run(async {
         let config = MockConfig::empty();

--- a/crates/core/src/route_handler.rs
+++ b/crates/core/src/route_handler.rs
@@ -241,8 +241,15 @@ pub struct RequestInfo<'a> {
     /// The original path as seen by the client, used for SigV4 signature
     /// verification when the proxy rewrites paths before dispatch.
     ///
+    /// This **must** be the raw, percent-**encoded** path exactly as the client
+    /// sent (and signed) it — e.g. `/bucket/my%20key`, not the decoded
+    /// `/bucket/my key`. The SigV4 canonical URI is the encoded path, so a
+    /// decoded path (such as one that has been through `percent_decode`) will
+    /// fail with `SignatureDoesNotMatch` for any key containing an escaped
+    /// character (space, `#`, non-ASCII, …).
+    ///
     /// When `None`, `path` is used for both operation parsing and signature
-    /// verification.
+    /// verification — so if `path` is decoded, set this explicitly.
     pub signing_path: Option<&'a str>,
     /// The original query string as seen by the client, used for SigV4
     /// signature verification when the proxy rewrites query parameters.
@@ -276,7 +283,9 @@ impl<'a> RequestInfo<'a> {
     /// Set the original client-facing path for SigV4 signature verification.
     ///
     /// Use this when the proxy rewrites paths (e.g. path-mapping) so that
-    /// signature verification uses the path the client actually signed.
+    /// signature verification uses the path the client actually signed. Pass the
+    /// raw, percent-**encoded** path (`/bucket/my%20key`), not the decoded form
+    /// — see [`RequestInfo::signing_path`] for why.
     pub fn with_signing_path(mut self, signing_path: &'a str) -> Self {
         self.signing_path = Some(signing_path);
         self

--- a/docs/architecture/crate-layout.md
+++ b/docs/architecture/crate-layout.md
@@ -93,7 +93,7 @@ The native server runtime (in `examples/server/`):
 
 The reusable Cloudflare Workers WASM runtime library (in `crates/cf-workers/`):
 - `WorkerBackend` implementing `ProxyBackend` with `web_sys::fetch`
-- `RequestParts` — extracts owned HTTP metadata from `web_sys::Request` and provides `as_request_info()` for gateway dispatch
+- `RequestParts` — extracts owned HTTP metadata from `web_sys::Request` and provides `as_request_info()` for gateway dispatch (exposes both the decoded `path` for routing and the raw encoded `signing_path` for SigV4, wiring the latter into the signing path automatically)
 - `GatewayResponseExt` — extension trait for converting `GatewayResponse` to `web_sys::Response` via `.into_web_sys()`
 - `JsBody` — zero-copy body wrapper around `web_sys::ReadableStream`
 - `WsHeaders` — newtype around `web_sys::Headers` with `From<&HeaderMap>` (works around orphan rules)

--- a/docs/extending/custom-backend.md
+++ b/docs/extending/custom-backend.md
@@ -156,7 +156,12 @@ let backend = MyBackend::new(http_client);
 let gateway = ProxyGateway::new(backend, bucket_registry, cred_registry, domain)
     .with_router(router);
 
-// In your request handler, use handle_request for a two-variant match:
+// In your request handler, use handle_request for a two-variant match.
+// `path` must be the raw, percent-encoded request path (the form the client
+// signed) — SigV4 verification canonicalizes over it. If you decode the path
+// for routing, pass the encoded path separately via `.with_signing_path()`,
+// or keys containing escaped characters (e.g. a space → `%20`) fail with
+// SignatureDoesNotMatch.
 let req_info = RequestInfo::new(&method, &path, query.as_deref(), &headers, None);
 match gateway.handle_request(&req_info, body, |b| to_bytes(b)).await {
     GatewayResponse::Response(result) => {

--- a/docs/extending/custom-resolver.md
+++ b/docs/extending/custom-resolver.md
@@ -102,7 +102,10 @@ let registry = MyRegistry::new(api_client);
 let cred_registry = MyCredentialRegistry::new(/* ... */);
 let gateway = ProxyGateway::new(backend, registry, cred_registry, domain);
 
-// In your request handler:
+// In your request handler. `path` must be the raw, percent-encoded request
+// path (the form the client signed); if you decode it for routing, pass the
+// encoded path separately via `.with_signing_path()` — otherwise keys with
+// escaped characters (e.g. a space → `%20`) fail with SignatureDoesNotMatch.
 let req_info = RequestInfo::new(&method, &path, query.as_deref(), &headers, None);
 match gateway.handle_request(&req_info, body, |b| to_bytes(b)).await {
     GatewayResponse::Response(result) => { /* return response */ }


### PR DESCRIPTION
## What I'm changing

Uploading an object whose key contains a character the client percent-escapes — most commonly a space (`foo bar` → `foo%20bar`) — fails with `403 SignatureDoesNotMatch`. SigV4's canonical URI is the **percent-encoded** path the client signs, but `RequestParts::from_web_sys` percent-*decodes* the path (correct — bucket/key routing needs the decoded key) and `as_request_info` then handed that **decoded** path through as the signing path. The reconstructed canonical request contained a literal space while the client signed `%20`, so it never matched.

This is a footgun beyond any one integrator:
- `as_request_info()` — the documented convenience path — set no signing path, so verification fell back to the decoded `RequestParts.path`. The simple integration was wrong by default.
- Nothing documented that `signing_path` must be the encoded wire path.
- The SigV4 test suite used only plain ASCII paths, so the whole class of bug had zero coverage.

Fixes the default and hardens the contract so integrators can't silently reintroduce it.

## How I did it

- **`crates/cf-workers/src/request.rs`** — `RequestParts` now keeps the raw, percent-encoded path in a new `signing_path` field (captured from `uri.path()` before decoding), and `as_request_info()` wires it into `RequestInfo` via `with_signing_path`. The decoded `path` is unchanged for routing. Simple integrations are now correct by construction.
- **`crates/core/src/route_handler.rs`** — documented on `RequestInfo::signing_path` and `with_signing_path` that the value **must** be the percent-encoded wire path (`/bucket/my%20key`), not the decoded form, and why a decoded path fails.
- **`crates/core/src/auth/sigv4.rs`** — on a signature mismatch, emit a targeted `warn!` when the signing path contains a literal space: the tell-tale of a decoded path reaching signing. (Non-fatal hint; catches the common case — this bug first surfaced in logs.)
- **`crates/core/src/auth/tests.rs`** — two `resolve_identity` regression tests: an encoded signing path (`/test-bucket/foo%20bar`) verifies; the decoded form (`/test-bucket/foo bar`) is rejected with `SignatureDoesNotMatch`.
- **`docs/architecture/crate-layout.md`** — note the decoded-`path` / encoded-`signing_path` split.
- **`Cargo.lock`** — separate `chore` commit syncing the stale lockfile (0.5.1 → 0.6.2) so the pre-commit hooks and CI run against a stable lock.

## Test plan

- [x] `cargo test` — full default-member suite passes, incl. the two new cases (`encoded_signing_path_verifies`, `decoded_signing_path_is_rejected`).
- [x] `cargo clippy --all-targets` — no new warnings (one pre-existing `too_many_arguments` on the `sign_request` test helper, untouched).
- [x] `cargo check` and `cargo check -p multistore-cf-workers --target wasm32-unknown-unknown`.

Note: `as_request_info` / `from_web_sys` take a `web_sys::Request`, and `multistore-cf-workers` only builds for `wasm32`, so the default fix itself isn't covered by a native test; the core-level tests lock the signing contract it depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)