### PR TITLE
fix(core): percent-encode object keys in raw-signed backend URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "multistore"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-cf-workers"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-cf-workers-example"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bytes",
  "console_error_panic_hook",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-lambda"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bytes",
  "http",
@@ -1214,7 +1214,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-metering"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bytes",
  "futures",
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-oidc-provider"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "base64",
  "chrono",
@@ -1246,7 +1246,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-path-mapping"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "multistore",
  "percent-encoding",
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-server"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "axum",
  "bytes",
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-static-config"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "chrono",
  "multistore",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-sts"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/crates/core/src/backend/multipart.rs
+++ b/crates/core/src/backend/multipart.rs
@@ -20,8 +20,8 @@ use url::Url;
 /// decoded request path, and `url::Url` leaves `=` and friends literal in
 /// paths — so the key must be encoded with this exact set before it is
 /// spliced into the URL, or the backend signature won't match
-/// (`SignatureDoesNotMatch`). Matches `object_store`'s presigned-path
-/// encoding, which is why plain PUT/GET on such keys already work.
+/// (`SignatureDoesNotMatch`). This is the same strict set `object_store`
+/// applies when building presigned URLs for the CRUD operations.
 const S3_PATH_ENCODE_SET: &percent_encoding::AsciiSet = &percent_encoding::NON_ALPHANUMERIC
     .remove(b'-')
     .remove(b'.')

--- a/crates/core/src/backend/multipart.rs
+++ b/crates/core/src/backend/multipart.rs
@@ -13,6 +13,22 @@ use crate::types::{BucketConfig, S3Operation};
 use http::{HeaderMap, Method};
 use url::Url;
 
+/// SigV4 canonical path encoding: everything but RFC 3986 unreserved
+/// characters is percent-encoded; `/` stays raw as the segment separator.
+///
+/// AWS (and MinIO) reconstruct the canonical URI by strict-encoding the
+/// decoded request path, and `url::Url` leaves `=` and friends literal in
+/// paths — so the key must be encoded with this exact set before it is
+/// spliced into the URL, or the backend signature won't match
+/// (`SignatureDoesNotMatch`). Matches `object_store`'s presigned-path
+/// encoding, which is why plain PUT/GET on such keys already work.
+const S3_PATH_ENCODE_SET: &percent_encoding::AsciiSet = &percent_encoding::NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'.')
+    .remove(b'_')
+    .remove(b'~')
+    .remove(b'/');
+
 /// Build the backend URL for an S3 operation.
 ///
 /// Used for multipart operations that go through raw signed HTTP.
@@ -40,6 +56,7 @@ pub fn build_backend_url(
         key.push('/');
     }
     key.push_str(operation.key());
+    let key = percent_encoding::utf8_percent_encode(&key, S3_PATH_ENCODE_SET).to_string();
 
     let mut url = if bucket_is_empty {
         format!("{}/{}", base, key)
@@ -189,6 +206,67 @@ mod tests {
             !url.contains("injected=true"),
             "upload_id was not encoded: {}",
             url
+        );
+    }
+
+    #[test]
+    fn key_special_chars_percent_encoded_in_backend_path() {
+        let config = test_bucket_config();
+        let op = S3Operation::CreateMultipartUpload {
+            bucket: "test".into(),
+            key: "by_country/country_iso=ETH/ETH file.pmtiles".into(),
+        };
+
+        let url = build_backend_url(&config, &op).unwrap();
+
+        // `=` and space are outside the AWS strict set and must be encoded;
+        // `/` stays raw as the segment separator.
+        assert_eq!(
+            url,
+            "https://s3.us-east-1.amazonaws.com/my-backend-bucket/by_country/country_iso%3DETH/ETH%20file.pmtiles?uploads"
+        );
+        // Url::parse must not re-encode the result: what sign_request signs
+        // (`url.path()`) is byte-identical to the wire path.
+        assert_eq!(
+            Url::parse(&url).unwrap().path(),
+            "/my-backend-bucket/by_country/country_iso%3DETH/ETH%20file.pmtiles"
+        );
+    }
+
+    #[test]
+    fn key_aws_special_chars_encoded_slash_preserved() {
+        let config = test_bucket_config();
+        let op = S3Operation::UploadPart {
+            bucket: "test".into(),
+            key: "p!('*'):@+,;$&/f.bin".into(),
+            upload_id: "uid".into(),
+            part_number: 1,
+        };
+
+        let url = build_backend_url(&config, &op).unwrap();
+
+        let path = url.split_once('?').unwrap().0;
+        assert_eq!(
+            path,
+            "https://s3.us-east-1.amazonaws.com/my-backend-bucket/p%21%28%27%2A%27%29%3A%40%2B%2C%3B%24%26/f.bin"
+        );
+    }
+
+    #[test]
+    fn key_with_literal_percent_triplet_is_double_encoded() {
+        // A key that literally contains `%3D` (already decoded upstream) must
+        // go out as `%253D`, not be mistaken for an encoded `=`.
+        let config = test_bucket_config();
+        let op = S3Operation::CreateMultipartUpload {
+            bucket: "test".into(),
+            key: "weird/%3D-literal.txt".into(),
+        };
+
+        let url = build_backend_url(&config, &op).unwrap();
+
+        assert_eq!(
+            url,
+            "https://s3.us-east-1.amazonaws.com/my-backend-bucket/weird/%253D-literal.txt?uploads"
         );
     }
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -340,7 +340,8 @@ class TestMultipartUploads:
             # object_store's PathPart INVALID set (`*`, `%`, `~`, `#`, ...)
             # are excluded: the presigned CRUD path rewrites those in the
             # logical key (`*` → `%2A`), so a byte-faithful multipart write
-            # can't be read back — a separate pre-existing limitation.
+            # can't be read back through it — a separate limitation of the
+            # presigned path.
             "specials !('):@+,;$&/part=2",
         ],
     )

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -330,6 +330,46 @@ class TestMultipartUploads:
 
         client.delete_object(Bucket="private-uploads", Key=key)
 
+    @pytest.mark.parametrize(
+        "key_stem",
+        [
+            # Hive-style partition path — data.source.coop#180.
+            "by_country/country_iso=ETH/ETH",
+            # The other chars the url crate leaves literal in paths but AWS
+            # strict-encodes when reconstructing the canonical URI. Chars in
+            # object_store's PathPart INVALID set (`*`, `%`, `~`, `#`, ...)
+            # are excluded: the presigned CRUD path rewrites those in the
+            # logical key (`*` → `%2A`), so a byte-faithful multipart write
+            # can't be read back — a separate pre-existing limitation.
+            "specials !('):@+,;$&/part=2",
+        ],
+    )
+    def test_multipart_special_char_key_roundtrip(self, key_stem):
+        """Multipart to a key with chars outside the RFC 3986 unreserved set.
+
+        The raw-signed backend URL must percent-encode these or the backend
+        (AWS/MinIO) re-encodes them server-side and rejects the signature with
+        SignatureDoesNotMatch at CreateMultipartUpload.
+        """
+        client = static_client()
+        key = f"{key_stem}-{uuid.uuid4()}.bin"
+        body = b"special-key-payload!" * (6 * MIB // 20 + 1)
+        body = body[: 6 * MIB]  # 6 MiB → two parts, forces multipart
+        config = TransferConfig(
+            multipart_threshold=5 * MIB,
+            multipart_chunksize=5 * MIB,
+            max_concurrency=1,
+            use_threads=False,
+        )
+
+        client.upload_fileobj(BytesIO(body), "private-uploads", key, Config=config)
+        # Reading back through the presigned GET path proves both paths agree
+        # on what the key is.
+        resp = client.get_object(Bucket="private-uploads", Key=key)
+        assert resp["Body"].read() == body
+
+        client.delete_object(Bucket="private-uploads", Key=key)
+
     def test_multipart_low_level_explicit(self):
         """Drive Create/UploadPart/Complete directly and verify the round-trip."""
         client = static_client()


### PR DESCRIPTION
## Problem

Multipart uploads to keys containing `=` (e.g. Hive-style partition paths like `by_country/country_iso=ETH/ETH.pmtiles`) fail with `403 SignatureDoesNotMatch` at `CreateMultipartUpload`. Single PUTs on the same keys work. Reported downstream as source-cooperative/data.source.coop#180, where large unsplittable files (PMTiles) on partition paths cannot be uploaded at all (single PUT is capped by the Workers ~100 MB body limit).

## Root cause

Raw-signed operations (multipart Create/UploadPart/Complete/Abort) build their backend URL in `build_backend_url` by splicing the **decoded** key into a string. `url::Url` leaves `=` — and the rest of `! ( ) : @ + , ; $ & '` — literal in paths, so the request went out **and was signed** with the literal byte. S3 (and MinIO — `s3utils.EncodePath`) reconstruct the SigV4 canonical URI by strict-encoding the decoded path (`=` → `%3D`), computing a different signature.

Presigned CRUD ops already encode with `object_store`'s `STRICT_ENCODE_SET`, which is why plain PUT/GET on these keys worked — the asymmetry was only in the raw-signed path.

## Fix

Encode the assembled `prefix + key` with the SigV4 strict set (RFC 3986 unreserved chars, `/` kept as the segment separator) before splicing. The URL string returned by `build_backend_url` is both the signing input (`sign_s3_request` signs `Url::parse(url).path()`, which does not re-encode `%`) and the wire bytes (`send_raw` passes the string to the Fetch `Request` constructor), so signature and wire stay byte-identical — no reliance on backend-specific canonicalization. One change covers all three call sites (`execute_multipart`, `build_streaming_forward`, `execute_delete_objects`; the last has no key in its URL). `percent-encoding` was already a direct dependency.

Keys legitimately containing a literal `%3D` round-trip correctly (`%` is encoded → `%253D`). Query strings (`uploadId`, `partNumber`) were already handled via `form_urlencoded` and are untouched, as is inbound signature verification (`signing_path`, #103).

## Tests

- **Unit** (`crates/core/src/backend/multipart.rs`): special chars encoded + `Url::parse` round-trip (canonical URI == wire path), full AWS-special set with `/` preserved, literal-`%3D` double-encoding.
- **Integration** (`tests/integration/test_integration.py`): parametrized multipart round-trip (upload via transfer manager → GET back → delete) against MinIO for a `country_iso=ETH` partition key and a kitchen-sink specials key.

Verified fail-before/pass-after locally with `scripts/integration-test.sh`:
- **Before the fix**: both parametrized cases fail with `SignatureDoesNotMatch` at `CreateMultipartUpload` — exact reproduction of the downstream issue.
- **After the fix**: full integration suite green (24 passed, 4 OIDC tests self-skipped locally), plus `cargo test` (126 tests), `cargo fmt`, `clippy`, and wasm `cargo check`.

## Known limitation surfaced (pre-existing, out of scope)

Characters in `object_store`'s `PathPart` INVALID set (`*`, `%`, `~`, `#`, `?`, `|`, `\`, `{`, `}`, `[`, `]`, `<`, `>`, `"`, `^`) are silently rewritten in the logical key by the **presigned** CRUD path (`Path::from` encodes `*` → `%2A`, so the backend object is created/fetched under the mangled key). Presigned PUT+GET round-trips are self-consistently mangled, but a byte-faithful multipart write of such a key can't be read back through the presigned GET. `*` is therefore excluded from the integration test's specials key (noted in a comment). Worth a follow-up issue if byte-faithful keys for those characters matter.

Also syncs `Cargo.lock` with the 0.6.3 release version bump (main's lock was stale; any local `cargo build` regenerates the same diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)