### PR TITLE
fix(deps): upgrade quick-xml to 0.41 for RUSTSEC-2026-0194/0195

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,4 +1,11 @@
 [advisories]
 ignore = [
     "RUSTSEC-2023-0071", # Marvin Attack on rsa crate - no fix available; used for JWT signing/verification, not decryption
+    # quick-xml DoS advisories (fixed in 0.41). Our own quick-xml — which parses
+    # client-supplied XML (CompleteMultipartUpload/DeleteObjects bodies) — is on
+    # 0.41. These entries cover only object_store's internal quick-xml (0.38.x;
+    # even object_store 0.14 requires ^0.40.1), which parses backend LIST
+    # responses, not client input. Remove when object_store ships quick-xml >=0.41.
+    "RUSTSEC-2026-0194", # quadratic runtime checking duplicate attribute names
+    "RUSTSEC-2026-0195", # unbounded namespace-declaration allocation in NsReader
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "multistore"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -1135,7 +1135,7 @@ dependencies = [
  "md-5",
  "object_store",
  "percent-encoding",
- "quick-xml 0.37.5",
+ "quick-xml 0.41.0",
  "serde",
  "serde_json",
  "sha2",
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-cf-workers"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-cf-workers-example"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bytes",
  "console_error_panic_hook",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-lambda"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bytes",
  "http",
@@ -1214,7 +1214,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-metering"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bytes",
  "futures",
@@ -1226,13 +1226,13 @@ dependencies = [
 
 [[package]]
 name = "multistore-oidc-provider"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "base64",
  "chrono",
  "futures",
  "multistore",
- "quick-xml 0.37.5",
+ "quick-xml 0.41.0",
  "rand 0.8.5",
  "rsa",
  "serde",
@@ -1246,7 +1246,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-path-mapping"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "multistore",
  "percent-encoding",
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-server"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "axum",
  "bytes",
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-static-config"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "chrono",
  "multistore",
@@ -1289,14 +1289,14 @@ dependencies = [
 
 [[package]]
 name = "multistore-sts"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "aes-gcm",
  "base64",
  "chrono",
  "http",
  "multistore",
- "quick-xml 0.37.5",
+ "quick-xml 0.41.0",
  "rand 0.8.5",
  "reqwest",
  "rsa",
@@ -1571,9 +1571,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
  "serde",
@@ -1581,9 +1581,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ object_store = { version = "0.13.1", default-features = false, features = ["aws"
 futures = "0.3"
 
 # XML
-quick-xml = { version = "0.37", features = ["serialize"] }
+quick-xml = { version = "0.41", features = ["serialize"] }
 
 # Auth
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }


### PR DESCRIPTION
## Problem

The Audit CI job fails on every PR since 2026-06-29: RUSTSEC-2026-0194 (quadratic duplicate-attribute checking) and RUSTSEC-2026-0195 (unbounded `NsReader` namespace allocation) flag both locked copies of quick-xml — our own 0.37.5 and object_store's internal 0.38.4. Both advisories are fixed in quick-xml 0.41.

## Fix

- **Bump our quick-xml to 0.41** (workspace dep used by `core`, `sts`, `oidc-provider`). This copy parses **client-supplied** XML — `CompleteMultipartUpload` and `DeleteObjects` request bodies — so it's the surface the DoS advisories actually threaten. The bump is drop-in: full test suite passes with no code changes.
- **Ignore the two advisory IDs in `.cargo/audit.toml`** (the file's existing pattern) to cover object_store's copy, which no consumer-side bump can fix — even object_store 0.14.0 requires quick-xml `^0.40.1`, still below the patched 0.41. That copy parses backend LIST responses rather than client input, a lower trust boundary. The comment marks the entries for removal once object_store ships quick-xml ≥ 0.41.

`cargo audit` now exits 0 (the 3 remaining "unsound" warnings — anyhow, rand — are informational and were already tolerated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)