### PR TITLE
ci(smoke-tests): gate smoke tests on a secrets-dependent readiness probe

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -93,15 +93,33 @@ jobs:
       - name: Wait for deployment to be live
         run: |
           URL="${{ steps.url.outputs.deploy_url }}"
-          for i in $(seq 1 30); do
-            if curl -sf -o /dev/null -w "%{http_code}" "$URL" 2>/dev/null; then
-              echo "Deployment is live"
-              exit 0
+          # A first-ever workers.dev name and freshly-put secrets both
+          # propagate eventually: a single 200 can come from a not-yet-
+          # consistent edge or a pre-secrets worker version, letting the
+          # smoke tests start too early (bare 404s / secretless 500s).
+          # OIDC discovery only mounts once OIDC_PROVIDER_KEY is loaded,
+          # so it proves the post-secrets version is serving; require
+          # consecutive successes so a flapping edge doesn't pass.
+          if [ "${{ inputs.set_secrets }}" = "true" ]; then
+            PROBE="$URL/.well-known/openid-configuration"
+          else
+            PROBE="$URL/"
+          fi
+          ok=0
+          for i in $(seq 1 90); do
+            if curl -sf -o /dev/null "$PROBE" 2>/dev/null; then
+              ok=$((ok+1))
+              if [ "$ok" -ge 3 ]; then
+                echo "Deployment is live (3 consecutive successful probes)"
+                exit 0
+              fi
+            else
+              ok=0
             fi
-            echo "Attempt $i: waiting for deployment..."
+            echo "Attempt $i: waiting for deployment (consecutive OKs: $ok)..."
             sleep 2
           done
-          echo "Deployment did not become live in time"
+          echo "Deployment did not become live in time (probe: $PROBE)"
           exit 1
 
   smoke-test:


### PR DESCRIPTION
## Problem

Smoke tests flake on the **first-ever** deploy of a new PR preview worker (`multistore-proxy-pr-N`): both #105 and #106 failed their first smoke run with bare Cloudflare 404s on every route plus a federation 500, then passed untouched on rerun.

Two propagation windows race the smoke job:
- a brand-new workers.dev name activates eventually across Cloudflare's network — during the window some requests get bare 404s (not proxy XML);
- secrets are `wrangler secret put` **after** the initial upload, so there's briefly a live worker version without `OIDC_PROVIDER_KEY` → federation mints fail with 500.

The "Wait for deployment to be live" gate passed on a **single 200 from `/`** — a route that needs neither config nor secrets — so it opened the gate before either window closed.

## Fix

Probe `/.well-known/openid-configuration` instead: the example worker mounts OIDC discovery only once `OIDC_PROVIDER_KEY` is loaded, so a 200 proves the post-secrets version is serving. Require **3 consecutive** successes (2s apart, counter resets on failure) so a flapping edge can't sneak one through, and extend the window to 3 minutes. When `set_secrets` is disabled the probe falls back to `/`.

Environment-agnostic: preview, staging, and production all set the OIDC secrets, and re-deploys of existing workers pass the probe immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)