### PR TITLE
fix(core): byte-faithful, consistently validated object keys across all backend paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,7 +1121,7 @@ dependencies = [
 
 [[package]]
 name = "multistore"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "async-trait",
  "base64",
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-cf-workers"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1170,7 +1170,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-cf-workers-example"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bytes",
  "console_error_panic_hook",
@@ -1194,7 +1194,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-lambda"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bytes",
  "http",
@@ -1214,7 +1214,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-metering"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "bytes",
  "futures",
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-oidc-provider"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "base64",
  "chrono",
@@ -1246,7 +1246,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-path-mapping"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "multistore",
  "percent-encoding",
@@ -1255,7 +1255,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-server"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "axum",
  "bytes",
@@ -1277,7 +1277,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-static-config"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "chrono",
  "multistore",
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-sts"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/crates/core/src/api/request.rs
+++ b/crates/core/src/api/request.rs
@@ -57,6 +57,7 @@ pub fn build_s3_operation(
     key: String,
     query: Option<&str>,
 ) -> Result<S3Operation, ProxyError> {
+    validate_key(&key)?;
     let query_params = parse_query_params(query);
 
     // Check for multipart upload query params
@@ -155,6 +156,35 @@ pub fn build_s3_operation(
     }
 }
 
+/// Validate a client-visible object key before any backend path is built.
+///
+/// Every backend URL builder must agree on what a key addresses. The
+/// presigned path's `Path::parse` rejects empty and `.`/`..` segments but
+/// silently strips a leading/trailing `/`; the raw-signed path
+/// (`build_backend_url`) would accept all of them — writing objects the
+/// presigned path can't address, breaking listings (object_store fails to
+/// parse listed keys with empty segments), and letting a literal `..` reach
+/// URL normalization. Reject the whole class loudly, once, for every keyed
+/// operation. Real S3 accepts these keys; the proxy is deliberately
+/// stricter. Batch-delete body keys are deliberately exempt — they never
+/// enter a URL path, and permissiveness there is the remediation route for
+/// legacy degenerate keys already on a backend.
+pub fn validate_key(key: &str) -> Result<(), ProxyError> {
+    if key.is_empty() {
+        return Ok(()); // bucket-level operation
+    }
+    let degenerate_segment = key
+        .split('/')
+        .any(|seg| seg.is_empty() || seg == "." || seg == "..");
+    if degenerate_segment || key.bytes().any(|b| b < 0x20 || b == 0x7f) {
+        return Err(ProxyError::InvalidRequest(format!(
+            "invalid object key {key:?}: empty, `.`, or `..` path segments, \
+             leading/trailing slashes, and control characters are not allowed"
+        )));
+    }
+    Ok(())
+}
+
 #[derive(Debug, Clone)]
 pub enum HostStyle {
     /// Path-style: `/{bucket}/{key}`
@@ -240,5 +270,34 @@ mod tests {
     fn plain_put_still_parses_as_put_object() {
         let op = parse(Method::PUT, "/b/k.txt", None, &http::HeaderMap::new()).unwrap();
         assert!(matches!(op, S3Operation::PutObject { .. }));
+    }
+
+    #[test]
+    fn degenerate_keys_are_rejected_for_every_keyed_operation() {
+        let headers = http::HeaderMap::new();
+        for key in [
+            "a//b.txt",
+            "a/./b.txt",
+            "a/../b.txt",
+            "/a.txt",
+            "dir/",
+            "a\nb",
+        ] {
+            for (method, query) in [
+                (Method::GET, None),
+                (Method::PUT, None),
+                (Method::DELETE, None),
+                (Method::POST, Some("uploads")),
+            ] {
+                let err = build_s3_operation(&method, "b".into(), key.into(), query).unwrap_err();
+                assert!(
+                    matches!(err, ProxyError::InvalidRequest(_)),
+                    "{method} of key {key:?} must be InvalidRequest, got {err:?}"
+                );
+            }
+        }
+        // Bucket-level operations (empty key) are unaffected.
+        assert!(parse(Method::GET, "/b", None, &headers).is_ok());
+        assert!(parse(Method::POST, "/b", Some("delete"), &headers).is_ok());
     }
 }

--- a/crates/core/src/backend/multipart.rs
+++ b/crates/core/src/backend/multipart.rs
@@ -20,8 +20,8 @@ use url::Url;
 /// decoded request path, and `url::Url` leaves `=` and friends literal in
 /// paths — so the key must be encoded with this exact set before it is
 /// spliced into the URL, or the backend signature won't match
-/// (`SignatureDoesNotMatch`). Matches `object_store`'s presigned-path
-/// encoding, which is why plain PUT/GET on such keys already work.
+/// (`SignatureDoesNotMatch`). This is the same strict set `object_store`
+/// applies when building presigned URLs for the CRUD operations.
 const S3_PATH_ENCODE_SET: &percent_encoding::AsciiSet = &percent_encoding::NON_ALPHANUMERIC
     .remove(b'-')
     .remove(b'.')

--- a/crates/core/src/backend/multipart.rs
+++ b/crates/core/src/backend/multipart.rs
@@ -51,6 +51,12 @@ pub fn build_backend_url(
         });
     }
 
+    // Backstop: keys are validated at operation-parse time
+    // (`build_s3_operation`); enforce here too so a hand-built operation can
+    // never splice a degenerate key (`a//b`, `..`) into a URL that
+    // normalizes to a different — possibly cross-bucket — target.
+    crate::api::request::validate_key(operation.key())?;
+
     let mut key = String::new();
     if let Some(prefix) = &config.backend_prefix {
         key.push_str(prefix.trim_end_matches('/'));
@@ -156,6 +162,21 @@ mod tests {
             anonymous_access: false,
             allowed_roles: vec![],
             backend_options,
+        }
+    }
+
+    #[test]
+    fn degenerate_keys_are_rejected_before_url_build() {
+        let config = test_bucket_config();
+        for key in ["a//b.txt", "a/../b.txt"] {
+            let op = S3Operation::CreateMultipartUpload {
+                bucket: "test".into(),
+                key: key.into(),
+            };
+            assert!(
+                build_backend_url(&config, &op).is_err(),
+                "hand-built op with key {key:?} must not reach the URL"
+            );
         }
     }
 

--- a/crates/core/src/backend/multipart.rs
+++ b/crates/core/src/backend/multipart.rs
@@ -13,6 +13,22 @@ use crate::types::{BucketConfig, S3Operation};
 use http::{HeaderMap, Method};
 use url::Url;
 
+/// SigV4 canonical path encoding: everything but RFC 3986 unreserved
+/// characters is percent-encoded; `/` stays raw as the segment separator.
+///
+/// AWS (and MinIO) reconstruct the canonical URI by strict-encoding the
+/// decoded request path, and `url::Url` leaves `=` and friends literal in
+/// paths — so the key must be encoded with this exact set before it is
+/// spliced into the URL, or the backend signature won't match
+/// (`SignatureDoesNotMatch`). Matches `object_store`'s presigned-path
+/// encoding, which is why plain PUT/GET on such keys already work.
+const S3_PATH_ENCODE_SET: &percent_encoding::AsciiSet = &percent_encoding::NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'.')
+    .remove(b'_')
+    .remove(b'~')
+    .remove(b'/');
+
 /// Build the backend URL for an S3 operation.
 ///
 /// Used for multipart operations that go through raw signed HTTP.
@@ -40,6 +56,7 @@ pub fn build_backend_url(
         key.push('/');
     }
     key.push_str(operation.key());
+    let key = percent_encoding::utf8_percent_encode(&key, S3_PATH_ENCODE_SET).to_string();
 
     let mut url = if bucket_is_empty {
         format!("{}/{}", base, key)
@@ -189,6 +206,67 @@ mod tests {
             !url.contains("injected=true"),
             "upload_id was not encoded: {}",
             url
+        );
+    }
+
+    #[test]
+    fn key_special_chars_percent_encoded_in_backend_path() {
+        let config = test_bucket_config();
+        let op = S3Operation::CreateMultipartUpload {
+            bucket: "test".into(),
+            key: "by_country/country_iso=ETH/ETH file.pmtiles".into(),
+        };
+
+        let url = build_backend_url(&config, &op).unwrap();
+
+        // `=` and space are outside the AWS strict set and must be encoded;
+        // `/` stays raw as the segment separator.
+        assert_eq!(
+            url,
+            "https://s3.us-east-1.amazonaws.com/my-backend-bucket/by_country/country_iso%3DETH/ETH%20file.pmtiles?uploads"
+        );
+        // Url::parse must not re-encode the result: what sign_request signs
+        // (`url.path()`) is byte-identical to the wire path.
+        assert_eq!(
+            Url::parse(&url).unwrap().path(),
+            "/my-backend-bucket/by_country/country_iso%3DETH/ETH%20file.pmtiles"
+        );
+    }
+
+    #[test]
+    fn key_aws_special_chars_encoded_slash_preserved() {
+        let config = test_bucket_config();
+        let op = S3Operation::UploadPart {
+            bucket: "test".into(),
+            key: "p!('*'):@+,;$&/f.bin".into(),
+            upload_id: "uid".into(),
+            part_number: 1,
+        };
+
+        let url = build_backend_url(&config, &op).unwrap();
+
+        let path = url.split_once('?').unwrap().0;
+        assert_eq!(
+            path,
+            "https://s3.us-east-1.amazonaws.com/my-backend-bucket/p%21%28%27%2A%27%29%3A%40%2B%2C%3B%24%26/f.bin"
+        );
+    }
+
+    #[test]
+    fn key_with_literal_percent_triplet_is_double_encoded() {
+        // A key that literally contains `%3D` (already decoded upstream) must
+        // go out as `%253D`, not be mistaken for an encoded `=`.
+        let config = test_bucket_config();
+        let op = S3Operation::CreateMultipartUpload {
+            bucket: "test".into(),
+            key: "weird/%3D-literal.txt".into(),
+        };
+
+        let url = build_backend_url(&config, &op).unwrap();
+
+        assert_eq!(
+            url,
+            "https://s3.us-east-1.amazonaws.com/my-backend-bucket/weird/%253D-literal.txt?uploads"
         );
     }
 

--- a/crates/core/src/backend/multipart.rs
+++ b/crates/core/src/backend/multipart.rs
@@ -22,12 +22,13 @@ use url::Url;
 /// spliced into the URL, or the backend signature won't match
 /// (`SignatureDoesNotMatch`). This is the same strict set `object_store`
 /// applies when building presigned URLs for the CRUD operations.
-const S3_PATH_ENCODE_SET: &percent_encoding::AsciiSet = &percent_encoding::NON_ALPHANUMERIC
-    .remove(b'-')
-    .remove(b'.')
-    .remove(b'_')
-    .remove(b'~')
-    .remove(b'/');
+pub(crate) const S3_PATH_ENCODE_SET: &percent_encoding::AsciiSet =
+    &percent_encoding::NON_ALPHANUMERIC
+        .remove(b'-')
+        .remove(b'.')
+        .remove(b'_')
+        .remove(b'~')
+        .remove(b'/');
 
 /// Build the backend URL for an S3 operation.
 ///

--- a/crates/core/src/backend/url_signer.rs
+++ b/crates/core/src/backend/url_signer.rs
@@ -90,7 +90,6 @@ impl Signer for UnsignedUrlSigner {
             super::multipart::S3_PATH_ENCODE_SET,
         )
         .to_string();
-        let key = key.as_str();
         let url_str = if self.bucket.is_empty() {
             if key.is_empty() {
                 format!("{}/", self.endpoint)

--- a/crates/core/src/backend/url_signer.rs
+++ b/crates/core/src/backend/url_signer.rs
@@ -80,7 +80,17 @@ impl Signer for UnsignedUrlSigner {
         path: &object_store::path::Path,
         _expires_in: std::time::Duration,
     ) -> object_store::Result<url::Url> {
-        let key = path.as_ref();
+        // Percent-encode the key with the same strict set as the signed
+        // builders: `url::Url` leaves `%` (and `=`, `*`, ...) literal in
+        // paths, so an unencoded splice puts raw key bytes on the wire and
+        // the backend's decode addresses a different object (a key holding
+        // a literal `%3D` decodes to `=`).
+        let key = percent_encoding::utf8_percent_encode(
+            path.as_ref(),
+            super::multipart::S3_PATH_ENCODE_SET,
+        )
+        .to_string();
+        let key = key.as_str();
         let url_str = if self.bucket.is_empty() {
             if key.is_empty() {
                 format!("{}/", self.endpoint)

--- a/crates/core/src/proxy.rs
+++ b/crates/core/src/proxy.rs
@@ -1556,7 +1556,9 @@ fn error_response(err: &ProxyError, resource: &str, request_id: &str, debug: boo
 ///
 /// `Path::parse` rejects keys with empty (`a//b`) or relative (`.`, `..`)
 /// segments; surface those as `InvalidRequest` (400) rather than silently
-/// collapsing them to a different key as `Path::from` did.
+/// collapsing them to a different key as `Path::from` did. It still strips
+/// one leading and one trailing `/` (same as `Path::from`), so directory
+/// markers like `dir/` silently address `dir` — a known residual gap.
 fn build_object_path(
     config: &BucketConfig,
     key: &str,

--- a/crates/core/src/proxy.rs
+++ b/crates/core/src/proxy.rs
@@ -1059,7 +1059,7 @@ where
         request_id: &str,
     ) -> Result<ForwardRequest, ProxyError> {
         let signer = self.backend.create_signer(config)?;
-        let path = build_object_path(config, key);
+        let path = build_object_path(config, key)?;
 
         let url = signer
             .signed_url(method.clone(), &path, PRESIGNED_URL_TTL)
@@ -1545,8 +1545,24 @@ fn error_response(err: &ProxyError, resource: &str, request_id: &str, debug: boo
 }
 
 /// Build an object_store Path from a bucket config and client-visible key.
-fn build_object_path(config: &BucketConfig, key: &str) -> object_store::path::Path {
-    object_store::path::Path::from(apply_backend_prefix(config, key))
+///
+/// Uses `Path::parse` (byte-faithful) rather than `Path::from`: `Path::from`
+/// percent-encodes characters object_store considers unsafe (`*`, `%`, `~`,
+/// `#`, ...) into the *logical* path, silently renaming the backend object
+/// (`a*.bin` is stored as `a%2A.bin`) and splitting the key namespace from
+/// the raw-signed multipart path, which stores keys byte-faithfully. With
+/// `Path::parse` the raw path is the key itself, and object_store's URL
+/// builder percent-encodes it exactly once at the wire boundary.
+///
+/// `Path::parse` rejects keys with empty (`a//b`) or relative (`.`, `..`)
+/// segments; surface those as `InvalidRequest` (400) rather than silently
+/// collapsing them to a different key as `Path::from` did.
+fn build_object_path(
+    config: &BucketConfig,
+    key: &str,
+) -> Result<object_store::path::Path, ProxyError> {
+    object_store::path::Path::parse(apply_backend_prefix(config, key))
+        .map_err(|e| ProxyError::InvalidRequest(format!("invalid object key: {e}")))
 }
 
 /// Parse the declared `Content-Length` header as a byte count, if present and valid.
@@ -2667,5 +2683,31 @@ mod tests {
                 "checksum headers missing from SignedHeaders: {auth}"
             );
         });
+    }
+
+    #[test]
+    fn object_path_is_byte_faithful() {
+        let config = test_bucket_config("test");
+        for key in ["report*.pdf", "100%.txt", "a~b#c.bin", "dir/%3D-lit.txt"] {
+            let path = build_object_path(&config, key).unwrap();
+            assert_eq!(path.as_ref(), key, "logical key must not be rewritten");
+        }
+    }
+
+    #[test]
+    fn object_path_applies_backend_prefix_byte_faithfully() {
+        let mut config = test_bucket_config("test");
+        config.backend_prefix = Some("data/".into());
+        let path = build_object_path(&config, "report*.pdf").unwrap();
+        assert_eq!(path.as_ref(), "data/report*.pdf");
+    }
+
+    #[test]
+    fn object_path_rejects_degenerate_segments() {
+        let config = test_bucket_config("test");
+        for key in ["a//b.txt", "a/./b.txt", "a/../b.txt"] {
+            let err = build_object_path(&config, key).unwrap_err();
+            assert_eq!(err.status_code(), 400, "key {key:?} must be a 400");
+        }
     }
 }

--- a/crates/core/src/proxy.rs
+++ b/crates/core/src/proxy.rs
@@ -1556,9 +1556,10 @@ fn error_response(err: &ProxyError, resource: &str, request_id: &str, debug: boo
 ///
 /// `Path::parse` rejects keys with empty (`a//b`) or relative (`.`, `..`)
 /// segments; surface those as `InvalidRequest` (400) rather than silently
-/// collapsing them to a different key as `Path::from` did. It still strips
-/// one leading and one trailing `/` (same as `Path::from`), so directory
-/// markers like `dir/` silently address `dir` — a known residual gap.
+/// collapsing them to a different key as `Path::from` did. This is a
+/// backstop: `validate_key` already rejects that class — plus leading and
+/// trailing slashes, which `Path::parse` would silently strip — for every
+/// keyed operation at parse time.
 fn build_object_path(
     config: &BucketConfig,
     key: &str,

--- a/crates/core/tests/key_encoding_contract.rs
+++ b/crates/core/tests/key_encoding_contract.rs
@@ -1,0 +1,129 @@
+//! Cross-path key-encoding contract.
+//!
+//! The proxy builds backend request paths in three places: object_store
+//! presigned URLs (authenticated CRUD), `UnsignedUrlSigner` (anonymous
+//! CRUD), and `build_backend_url` (raw-signed multipart and batch delete).
+//! A backend percent-decodes each wire path to decide which object a
+//! request addresses, so every builder must emit a path that decodes to
+//! the same logical key — and the builders must agree byte-for-byte, or
+//! the same logical key addresses different backend objects depending on
+//! upload size, client payload mode, or bucket auth (see #105, #108).
+//!
+//! If an object_store upgrade changes its path encoding, these tests are
+//! the loud alarm.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use multistore::backend::multipart::build_backend_url;
+use multistore::backend::url_signer::build_signer;
+use multistore::types::{BucketConfig, S3Operation};
+use object_store::path::Path;
+use percent_encoding::percent_decode_str;
+
+/// Corpus of logical keys: the plain case, every character class the url
+/// crate leaves literal in paths, and the characters object_store's
+/// `Path::from` used to rewrite.
+const KEYS: &[&str] = &[
+    "plain/file.bin",
+    "by_country/country_iso=ETH/ETH.pmtiles",
+    "spaces in/every segment.txt",
+    "specials !('):@+,;$&.bin",
+    "unicode/café/naïve.txt",
+    "report*.pdf",
+    "100%.txt",
+    "tilde~hash#pipe|.bin",
+    "brackets[1]{2}.bin",
+    "literal-%3D-triplet.txt",
+];
+
+fn bucket_config(with_creds: bool) -> BucketConfig {
+    let mut backend_options: HashMap<String, String> = HashMap::new();
+    backend_options.insert(
+        "endpoint".into(),
+        "https://s3.us-east-1.amazonaws.com".into(),
+    );
+    backend_options.insert("bucket_name".into(), "backend-bucket".into());
+    backend_options.insert("region".into(), "us-east-1".into());
+    if with_creds {
+        backend_options.insert("access_key_id".into(), "AKIAIOSFODNN7EXAMPLE".into());
+        backend_options.insert(
+            "secret_access_key".into(),
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into(),
+        );
+    }
+    BucketConfig {
+        name: "test".into(),
+        backend_type: "s3".into(),
+        backend_prefix: None,
+        anonymous_access: !with_creds,
+        allowed_roles: vec![],
+        backend_options,
+    }
+}
+
+/// Wire path emitted by the presigned CRUD builder (object_store signer
+/// for authenticated buckets, `UnsignedUrlSigner` for anonymous ones).
+/// `Path::parse` mirrors `build_object_path`.
+fn presigned_path(config: &BucketConfig, key: &str) -> String {
+    let signer = build_signer(config).unwrap();
+    let path = Path::parse(key).unwrap();
+    let url = futures::executor::block_on(signer.signed_url(
+        http::Method::GET,
+        &path,
+        Duration::from_secs(60),
+    ))
+    .unwrap();
+    url.path().to_string()
+}
+
+/// Wire path emitted by the raw-signed builder (multipart, batch delete).
+fn raw_signed_path(config: &BucketConfig, key: &str) -> String {
+    let op = S3Operation::CreateMultipartUpload {
+        bucket: "test".into(),
+        key: key.into(),
+    };
+    let url = build_backend_url(config, &op).unwrap();
+    url::Url::parse(&url).unwrap().path().to_string()
+}
+
+/// The two SigV4 builders (authenticated presign, raw-signed) and the
+/// anonymous builder must produce byte-identical wire paths for the same
+/// logical key.
+#[test]
+fn all_builders_agree_byte_for_byte() {
+    let authed = bucket_config(true);
+    let anon = bucket_config(false);
+    for key in KEYS {
+        let presigned = presigned_path(&authed, key);
+        let raw = raw_signed_path(&authed, key);
+        let unsigned = presigned_path(&anon, key);
+        assert_eq!(presigned, raw, "presigned vs raw-signed for key {key:?}");
+        assert_eq!(
+            presigned, unsigned,
+            "presigned vs anonymous for key {key:?}"
+        );
+    }
+}
+
+/// Every wire path must percent-decode back to exactly the logical key —
+/// that decode is what the backend uses to pick the object.
+#[test]
+fn wire_paths_decode_to_the_logical_key() {
+    for with_creds in [true, false] {
+        let config = bucket_config(with_creds);
+        for key in KEYS {
+            for (builder, path) in [
+                ("presigned", presigned_path(&config, key)),
+                ("raw-signed", raw_signed_path(&config, key)),
+            ] {
+                let decoded = percent_decode_str(&path).decode_utf8().unwrap();
+                assert_eq!(
+                    decoded,
+                    format!("/backend-bucket/{key}"),
+                    "{builder} (creds={with_creds}) for key {key:?}"
+                );
+            }
+        }
+    }
+}

--- a/crates/core/tests/key_encoding_contract.rs
+++ b/crates/core/tests/key_encoding_contract.rs
@@ -107,23 +107,14 @@ fn all_builders_agree_byte_for_byte() {
 }
 
 /// Every wire path must percent-decode back to exactly the logical key —
-/// that decode is what the backend uses to pick the object.
+/// that decode is what the backend uses to pick the object. One builder
+/// suffices: `all_builders_agree_byte_for_byte` pins the others to it.
 #[test]
 fn wire_paths_decode_to_the_logical_key() {
-    for with_creds in [true, false] {
-        let config = bucket_config(with_creds);
-        for key in KEYS {
-            for (builder, path) in [
-                ("presigned", presigned_path(&config, key)),
-                ("raw-signed", raw_signed_path(&config, key)),
-            ] {
-                let decoded = percent_decode_str(&path).decode_utf8().unwrap();
-                assert_eq!(
-                    decoded,
-                    format!("/backend-bucket/{key}"),
-                    "{builder} (creds={with_creds}) for key {key:?}"
-                );
-            }
-        }
+    let config = bucket_config(true);
+    for key in KEYS {
+        let path = presigned_path(&config, key);
+        let decoded = percent_decode_str(&path).decode_utf8().unwrap();
+        assert_eq!(decoded, format!("/backend-bucket/{key}"), "key {key:?}");
     }
 }

--- a/docs/reference/operations.md
+++ b/docs/reference/operations.md
@@ -55,6 +55,8 @@ Handled by OIDC discovery closures (registered on the `Router` via `OidcRouterEx
 > - **Server-side copy is not supported** — A `PUT` carrying `x-amz-copy-source` (CopyObject / UploadPartCopy) is rejected with `501 NotImplemented` rather than silently overwriting the destination.
 > - **`x-amz-*` write headers are dropped** — Object metadata, storage class, tagging, ACLs, SSE, and checksum headers on writes are not forwarded (see "Writes and request headers" above).
 > - **Versioned/MFA delete is not handled** — A `?versionId=` on a delete is ignored; the current object version is deleted.
+> - **Degenerate object keys are rejected** — Keys containing empty, `.`, or `..` path segments (including leading/trailing slashes, e.g. `dir/` folder markers), or ASCII control characters, return `400 InvalidRequest` on every keyed operation. Real S3 accepts such keys; the proxy is deliberately stricter because they cannot be addressed consistently across its presigned and raw-signed backend paths. Batch-delete body keys are exempt, as the remediation route for legacy keys already stored under such names.
+> - **Keys are otherwise byte-faithful** — All other keys (including `*`, `%`, `~`, `#`, unicode) are stored on the backend exactly as sent. Objects written through versions **before 0.6.4** via single presigned PUT with characters in object_store's rewrite set (`*`, `%`, `~`, `#`, `?`, `[`, `]`, ...) were silently stored under percent-encoded names (`a*.bin` as `a%2A.bin`); they remain addressable only by that literal mangled name and need a one-time rename to recover their logical keys.
 
 ### Upload size on the Cloudflare Workers runtime
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -340,7 +340,8 @@ class TestMultipartUploads:
             # object_store's PathPart INVALID set (`*`, `%`, `~`, `#`, ...)
             # are excluded: the presigned CRUD path rewrites those in the
             # logical key (`*` → `%2A`), so a byte-faithful multipart write
-            # can't be read back — a separate pre-existing limitation.
+            # can't be read back through it — a separate limitation of the
+            # presigned path.
             "specials !('):@+,;$&/part=2",
         ],
     )

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -515,14 +515,24 @@ class TestByteFaithfulKeys:
 
         client.delete_object(Bucket="private-uploads", Key=key)
 
-    def test_degenerate_key_segments_rejected(self):
-        # `Path::from` silently collapsed `a//b` to `a/b` (a different key);
-        # empty segments must now be loud 400s instead of silent rewrites.
+    def test_degenerate_keys_rejected_on_every_path(self):
+        # `Path::from` silently collapsed `a//b` to `a/b` and `dir/` to `dir`
+        # (different keys); the shared validator makes these loud 400s on
+        # every keyed operation — including the raw-signed multipart path,
+        # which would otherwise accept keys the presigned path can't address.
+        # Real S3 accepts such keys; the proxy is deliberately stricter.
         # (`..` segments are collapsed by WHATWG URL parsing at the edge
-        # before the proxy sees them, so only the unit test covers those.)
+        # before the proxy sees them, so only the unit tests cover those.)
         client = static_client()
+        for key in ("faithful/a//b.txt", "faithful/dir/"):
+            with pytest.raises(ClientError) as exc_info:
+                client.put_object(Bucket="private-uploads", Key=key, Body=b"x")
+            assert exc_info.value.response["Error"]["Code"] == "InvalidRequest"
+
         with pytest.raises(ClientError) as exc_info:
-            client.put_object(Bucket="private-uploads", Key="faithful/a//b.txt", Body=b"x")
+            client.create_multipart_upload(
+                Bucket="private-uploads", Key="faithful/a//b.txt"
+            )
         assert exc_info.value.response["Error"]["Code"] == "InvalidRequest"
 
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -435,6 +435,99 @@ class TestMultipartUploads:
 
 
 # ---------------------------------------------------------------------------
+# Byte-faithful keys
+# ---------------------------------------------------------------------------
+
+class TestByteFaithfulKeys:
+    """Keys with chars object_store's `Path::from` rewrites (`*`, `%`, `~`, ...)
+    must round-trip byte-faithfully through every path: the backend object
+    carries the exact requested key, and the presigned CRUD path and the
+    raw-signed multipart path agree on what that key is.
+    """
+
+    @staticmethod
+    def _backend_client():
+        """Direct MinIO client, bypassing the proxy, to inspect stored keys."""
+        return boto3.client(
+            "s3",
+            endpoint_url="http://localhost:9000",
+            aws_access_key_id="minioadmin",
+            aws_secret_access_key="minioadmin",
+            region_name="us-east-1",
+        )
+
+    def test_star_key_stored_byte_faithfully(self):
+        client = static_client()
+        prefix = f"faithful-{uuid.uuid4()}"
+        key = f"{prefix}/report*.pdf"
+
+        client.put_object(Bucket="private-uploads", Key=key, Body=b"star")
+
+        backend_keys = [
+            o["Key"]
+            for o in self._backend_client()
+            .list_objects_v2(Bucket="private-uploads", Prefix=prefix)
+            .get("Contents", [])
+        ]
+        assert backend_keys == [key], "backend object must carry the exact key"
+
+        resp = client.get_object(Bucket="private-uploads", Key=key)
+        assert resp["Body"].read() == b"star"
+
+        client.delete_object(Bucket="private-uploads", Key=key)
+        assert (
+            client.list_objects_v2(Bucket="private-uploads", Prefix=prefix).get(
+                "KeyCount", 0
+            )
+            == 0
+        )
+
+    def test_percent_keys_are_distinct_objects(self):
+        # `100%.txt` and `100%25.txt` must never alias to one backend object.
+        client = static_client()
+        prefix = f"faithful-{uuid.uuid4()}"
+        k1, k2 = f"{prefix}/100%.txt", f"{prefix}/100%25.txt"
+
+        client.put_object(Bucket="private-uploads", Key=k1, Body=b"A")
+        client.put_object(Bucket="private-uploads", Key=k2, Body=b"B")
+
+        assert client.get_object(Bucket="private-uploads", Key=k1)["Body"].read() == b"A"
+        assert client.get_object(Bucket="private-uploads", Key=k2)["Body"].read() == b"B"
+
+        for k in (k1, k2):
+            client.delete_object(Bucket="private-uploads", Key=k)
+
+    def test_multipart_write_presigned_read_agree(self):
+        # Multipart (raw-signed) writes byte-faithfully; GET (presigned) must
+        # address the same backend key.
+        client = static_client()
+        key = f"faithful-{uuid.uuid4()}/mp*.bin"
+        body = b"y" * (6 * MIB)
+        config = TransferConfig(
+            multipart_threshold=5 * MIB,
+            multipart_chunksize=5 * MIB,
+            max_concurrency=1,
+            use_threads=False,
+        )
+
+        client.upload_fileobj(BytesIO(body), "private-uploads", key, Config=config)
+        resp = client.get_object(Bucket="private-uploads", Key=key)
+        assert resp["Body"].read() == body
+
+        client.delete_object(Bucket="private-uploads", Key=key)
+
+    def test_degenerate_key_segments_rejected(self):
+        # `Path::from` silently collapsed `a//b` to `a/b` (a different key);
+        # empty segments must now be loud 400s instead of silent rewrites.
+        # (`..` segments are collapsed by WHATWG URL parsing at the edge
+        # before the proxy sees them, so only the unit test covers those.)
+        client = static_client()
+        with pytest.raises(ClientError) as exc_info:
+            client.put_object(Bucket="private-uploads", Key="faithful/a//b.txt", Body=b"x")
+        assert exc_info.value.response["Error"]["Code"] == "InvalidRequest"
+
+
+# ---------------------------------------------------------------------------
 # Static credential reads
 # ---------------------------------------------------------------------------
 

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -330,6 +330,46 @@ class TestMultipartUploads:
 
         client.delete_object(Bucket="private-uploads", Key=key)
 
+    @pytest.mark.parametrize(
+        "key_stem",
+        [
+            # Hive-style partition path — data.source.coop#180.
+            "by_country/country_iso=ETH/ETH",
+            # The other chars the url crate leaves literal in paths but AWS
+            # strict-encodes when reconstructing the canonical URI. Chars in
+            # object_store's PathPart INVALID set (`*`, `%`, `~`, `#`, ...)
+            # are excluded: the presigned CRUD path rewrites those in the
+            # logical key (`*` → `%2A`), so a byte-faithful multipart write
+            # can't be read back — a separate pre-existing limitation.
+            "specials !('):@+,;$&/part=2",
+        ],
+    )
+    def test_multipart_special_char_key_roundtrip(self, key_stem):
+        """Multipart to a key with chars outside the RFC 3986 unreserved set.
+
+        The raw-signed backend URL must percent-encode these or the backend
+        (AWS/MinIO) re-encodes them server-side and rejects the signature with
+        SignatureDoesNotMatch at CreateMultipartUpload.
+        """
+        client = static_client()
+        key = f"{key_stem}-{uuid.uuid4()}.bin"
+        body = b"special-key-payload!" * (6 * MIB // 20 + 1)
+        body = body[: 6 * MIB]  # 6 MiB → two parts, forces multipart
+        config = TransferConfig(
+            multipart_threshold=5 * MIB,
+            multipart_chunksize=5 * MIB,
+            max_concurrency=1,
+            use_threads=False,
+        )
+
+        client.upload_fileobj(BytesIO(body), "private-uploads", key, Config=config)
+        # Reading back through the presigned GET path proves both paths agree
+        # on what the key is.
+        resp = client.get_object(Bucket="private-uploads", Key=key)
+        assert resp["Body"].read() == body
+
+        client.delete_object(Bucket="private-uploads", Key=key)
+
     def test_multipart_low_level_explicit(self):
         """Drive Create/UploadPart/Complete directly and verify the round-trip."""
         client = static_client()

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -336,12 +336,11 @@ class TestMultipartUploads:
             # Hive-style partition path — data.source.coop#180.
             "by_country/country_iso=ETH/ETH",
             # The other chars the url crate leaves literal in paths but AWS
-            # strict-encodes when reconstructing the canonical URI. Chars in
-            # object_store's PathPart INVALID set (`*`, `%`, `~`, `#`, ...)
-            # are excluded: the presigned CRUD path rewrites those in the
-            # logical key (`*` → `%2A`), so a byte-faithful multipart write
-            # can't be read back through it — a separate limitation of the
-            # presigned path.
+            # strict-encodes when reconstructing the canonical URI. The
+            # object_store PathPart INVALID set (`*`, `%`, `~`, `#`, ...) is
+            # covered by the cross-path contract test
+            # (crates/core/tests/key_encoding_contract.rs) and by
+            # TestByteFaithfulKeys.
             "specials !('):@+,;$&/part=2",
         ],
     )


### PR DESCRIPTION
## Problem

The proxy builds backend request paths in three places, and they disagreed on what a logical key means:

1. **Presigned CRUD** (`build_object_path`) used `object_store::path::Path::from`, which percent-encodes characters object_store deems unsafe (`*`, `%`, `~`, `#`, `?`, `[`, `]`, ...) **into the logical path**, silently renaming objects on the backend. Verified live against MinIO:
   - Presigned PUT of `star*.txt` creates backend object `star%2A.txt` — a silent rename invisible to the uploader (self-round-trip works) but visible in listings, to direct bucket consumers, and to any list-then-fetch client (404).
   - A multipart-written `mp*.txt` (true key, post-#105) is **unreadable and undeletable** through the presigned path (GET → NoSuchKey, DELETE → silent 204 no-op).
   - `100%.txt` and `100%25.txt` can **alias to the same backend object**: a GET then returns the wrong file's contents with a 200.
2. **Anonymous CRUD** (`UnsignedUrlSigner`, used for credential-less backends) spliced the raw key into a URL string with no encoding: a key holding a literal `%3D` decoded to `=` on the backend, and once keys are byte-faithful, `#`/`?` would truncate the wire path at the fragment/query boundary.
3. **Raw-signed multipart / aws-chunked** (`build_backend_url`) accepted degenerate keys the other paths can't address: `a//b.txt` written via multipart is unreadable and undeletable via presigned and **breaks every listing page that covers it** (object_store fails parsing listed keys with empty segments), and a literal `..` segment survives to `url::Url::parse` normalization — on runtimes that don't WHATWG-normalize request paths (e.g. the axum server example; CF Workers normalizes and is safe), that retargets the signed backend request **across buckets**.

## Fix

- `build_object_path`: `Path::from` → `Path::parse`. Byte-faithful; object_store's URL builder then percent-encodes the raw path exactly once at the wire boundary.
- `UnsignedUrlSigner`: percent-encode the key with the same strict set the signed builders use (shared `S3_PATH_ENCODE_SET`).
- New `validate_key`, called once in `build_s3_operation` for every keyed operation: keys with empty, `.`, or `..` segments (including leading/trailing slashes, e.g. `dir/` folder markers) or ASCII control characters return `400 InvalidRequest` instead of being silently rewritten (`Path::from` collapsed `a//b` → `a/b`; `Path::parse` strips `dir/` → `dir`, so a DELETE of `a/` deleted `a`) or written where other paths can't address them. `build_backend_url` enforces the same rule as a backstop for hand-built operations. Real S3 accepts such keys; the proxy is deliberately stricter — documented in `docs/reference/operations.md`. Batch-delete body keys are exempt: they never enter a URL path, and permissiveness there is the remediation route for legacy degenerate keys.

All three builders now emit byte-identical wire paths that percent-decode back to exactly the logical key — and agree on the rejected set.

## Tests

- **Contract** (`crates/core/tests/key_encoding_contract.rs`): for a corpus covering every character class that has diverged before (`=` from #105, spaces, `*`/`%`/`~`/`#`, unicode, literal `%3D`), all three builders emit byte-identical wire paths that decode back to the logical key. Loud alarm if an object_store upgrade changes its encoding.
- **Unit**: byte-faithful round-trip and prefix application; degenerate keys → `InvalidRequest` for every keyed operation; hand-built degenerate operations can't reach a backend URL.
- **Integration** (MinIO): the backend object carries the exact requested key on presigned PUT (verified with a direct-to-MinIO client); `100%.txt` vs `100%25.txt` stay distinct objects; multipart write + presigned GET agree on a `*` key; `a//b` and `dir/` → 400 on both single PUT and multipart create. (`..` segments are collapsed by WHATWG URL parsing at the CF Workers edge before the proxy sees them; the unit tests cover those.)

## ⚠️ Migration notes

1. **Previously mangled names stay mangled.** Objects stored under percent-encoded names by earlier versions (`star%2A.txt`) keep those literal backend names: after this change they're addressable by that literal name rather than the original logical one. If any production data contains keys with the affected characters, a one-time rename sweep is needed. The affected character set is rare in real keys, and multipart uploads never produced mangled names (pre-#105 they failed outright for every affected character except `~`, whose keys were stored byte-faithfully), so the exposure is bounded to presigned single PUTs.
2. **New 400s.** Keys with empty, `.`, or `..` segments, leading/trailing slashes (`dir/` folder markers), or control characters now return `400 InvalidRequest` on every keyed operation. Real S3 accepts these keys; previously the proxy either silently rewrote them to a different key or wrote objects its other paths couldn't address. Batch delete still accepts them in its body, as the remediation path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
