### PR TITLE
test(core): cross-path key-encoding contract; encode keys in unsigned URLs

### DIFF
--- a/crates/core/src/backend/multipart.rs
+++ b/crates/core/src/backend/multipart.rs
@@ -22,12 +22,13 @@ use url::Url;
 /// spliced into the URL, or the backend signature won't match
 /// (`SignatureDoesNotMatch`). This is the same strict set `object_store`
 /// applies when building presigned URLs for the CRUD operations.
-const S3_PATH_ENCODE_SET: &percent_encoding::AsciiSet = &percent_encoding::NON_ALPHANUMERIC
-    .remove(b'-')
-    .remove(b'.')
-    .remove(b'_')
-    .remove(b'~')
-    .remove(b'/');
+pub(crate) const S3_PATH_ENCODE_SET: &percent_encoding::AsciiSet =
+    &percent_encoding::NON_ALPHANUMERIC
+        .remove(b'-')
+        .remove(b'.')
+        .remove(b'_')
+        .remove(b'~')
+        .remove(b'/');
 
 /// Build the backend URL for an S3 operation.
 ///

--- a/crates/core/src/backend/url_signer.rs
+++ b/crates/core/src/backend/url_signer.rs
@@ -80,7 +80,17 @@ impl Signer for UnsignedUrlSigner {
         path: &object_store::path::Path,
         _expires_in: std::time::Duration,
     ) -> object_store::Result<url::Url> {
-        let key = path.as_ref();
+        // Percent-encode the key with the same strict set as the signed
+        // builders: `url::Url` leaves `%` (and `=`, `*`, ...) literal in
+        // paths, so an unencoded splice puts raw key bytes on the wire and
+        // the backend's decode addresses a different object (a key holding
+        // a literal `%3D` decodes to `=`).
+        let key = percent_encoding::utf8_percent_encode(
+            path.as_ref(),
+            super::multipart::S3_PATH_ENCODE_SET,
+        )
+        .to_string();
+        let key = key.as_str();
         let url_str = if self.bucket.is_empty() {
             if key.is_empty() {
                 format!("{}/", self.endpoint)

--- a/crates/core/tests/key_encoding_contract.rs
+++ b/crates/core/tests/key_encoding_contract.rs
@@ -1,0 +1,129 @@
+//! Cross-path key-encoding contract.
+//!
+//! The proxy builds backend request paths in three places: object_store
+//! presigned URLs (authenticated CRUD), `UnsignedUrlSigner` (anonymous
+//! CRUD), and `build_backend_url` (raw-signed multipart and batch delete).
+//! A backend percent-decodes each wire path to decide which object a
+//! request addresses, so every builder must emit a path that decodes to
+//! the same logical key — and the builders must agree byte-for-byte, or
+//! the same logical key addresses different backend objects depending on
+//! upload size, client payload mode, or bucket auth (see #105, #108).
+//!
+//! If an object_store upgrade changes its path encoding, these tests are
+//! the loud alarm.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use multistore::backend::multipart::build_backend_url;
+use multistore::backend::url_signer::build_signer;
+use multistore::types::{BucketConfig, S3Operation};
+use object_store::path::Path;
+use percent_encoding::percent_decode_str;
+
+/// Corpus of logical keys: the plain case, every character class the url
+/// crate leaves literal in paths, and the characters object_store's
+/// `Path::from` used to rewrite.
+const KEYS: &[&str] = &[
+    "plain/file.bin",
+    "by_country/country_iso=ETH/ETH.pmtiles",
+    "spaces in/every segment.txt",
+    "specials !('):@+,;$&.bin",
+    "unicode/café/naïve.txt",
+    "report*.pdf",
+    "100%.txt",
+    "tilde~hash#pipe|.bin",
+    "brackets[1]{2}.bin",
+    "literal-%3D-triplet.txt",
+];
+
+fn bucket_config(with_creds: bool) -> BucketConfig {
+    let mut backend_options: HashMap<String, String> = HashMap::new();
+    backend_options.insert(
+        "endpoint".into(),
+        "https://s3.us-east-1.amazonaws.com".into(),
+    );
+    backend_options.insert("bucket_name".into(), "backend-bucket".into());
+    backend_options.insert("region".into(), "us-east-1".into());
+    if with_creds {
+        backend_options.insert("access_key_id".into(), "AKIAIOSFODNN7EXAMPLE".into());
+        backend_options.insert(
+            "secret_access_key".into(),
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into(),
+        );
+    }
+    BucketConfig {
+        name: "test".into(),
+        backend_type: "s3".into(),
+        backend_prefix: None,
+        anonymous_access: !with_creds,
+        allowed_roles: vec![],
+        backend_options,
+    }
+}
+
+/// Wire path emitted by the presigned CRUD builder (object_store signer
+/// for authenticated buckets, `UnsignedUrlSigner` for anonymous ones).
+/// `Path::parse` mirrors `build_object_path`.
+fn presigned_path(config: &BucketConfig, key: &str) -> String {
+    let signer = build_signer(config).unwrap();
+    let path = Path::parse(key).unwrap();
+    let url = futures::executor::block_on(signer.signed_url(
+        http::Method::GET,
+        &path,
+        Duration::from_secs(60),
+    ))
+    .unwrap();
+    url.path().to_string()
+}
+
+/// Wire path emitted by the raw-signed builder (multipart, batch delete).
+fn raw_signed_path(config: &BucketConfig, key: &str) -> String {
+    let op = S3Operation::CreateMultipartUpload {
+        bucket: "test".into(),
+        key: key.into(),
+    };
+    let url = build_backend_url(config, &op).unwrap();
+    url::Url::parse(&url).unwrap().path().to_string()
+}
+
+/// The two SigV4 builders (authenticated presign, raw-signed) and the
+/// anonymous builder must produce byte-identical wire paths for the same
+/// logical key.
+#[test]
+fn all_builders_agree_byte_for_byte() {
+    let authed = bucket_config(true);
+    let anon = bucket_config(false);
+    for key in KEYS {
+        let presigned = presigned_path(&authed, key);
+        let raw = raw_signed_path(&authed, key);
+        let unsigned = presigned_path(&anon, key);
+        assert_eq!(presigned, raw, "presigned vs raw-signed for key {key:?}");
+        assert_eq!(
+            presigned, unsigned,
+            "presigned vs anonymous for key {key:?}"
+        );
+    }
+}
+
+/// Every wire path must percent-decode back to exactly the logical key —
+/// that decode is what the backend uses to pick the object.
+#[test]
+fn wire_paths_decode_to_the_logical_key() {
+    for with_creds in [true, false] {
+        let config = bucket_config(with_creds);
+        for key in KEYS {
+            for (builder, path) in [
+                ("presigned", presigned_path(&config, key)),
+                ("raw-signed", raw_signed_path(&config, key)),
+            ] {
+                let decoded = percent_decode_str(&path).decode_utf8().unwrap();
+                assert_eq!(
+                    decoded,
+                    format!("/backend-bucket/{key}"),
+                    "{builder} (creds={with_creds}) for key {key:?}"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
> Stacked on #108 (which is stacked on #105); auto-retargets as those merge.

## What

Adds `crates/core/tests/key_encoding_contract.rs`: for a corpus of logical keys covering every character class that has diverged before (`=` from #105, spaces, `*`/`%`/`~`/`#` from #108, unicode, literal `%3D`), assert that all three backend URL builders — the authenticated presigned signer, the anonymous `UnsignedUrlSigner`, and the raw-signed `build_backend_url` — emit **byte-identical wire paths** that **percent-decode back to exactly the logical key** (the decode is what the backend uses to pick the object). If an object_store upgrade ever shifts its path encoding, these tests are the loud alarm.

## What the test caught immediately

A third instance of the #105 bug class: `UnsignedUrlSigner` (anonymous buckets) spliced the raw key into the URL with **no encoding**. Consequences on the wire:

- a key containing a literal `%3D` decodes to `=` on the backend — wrong object addressed;
- a key containing `#` gets truncated at the `#` by URL parsing (becomes a fragment);
- `=`, `*`, etc. go out literal while the other builders send `%3D`/`%2A` — the same cross-path split-brain #108 fixes for authenticated buckets.

Fixed by encoding with the same strict set as the signed builders (`S3_PATH_ENCODE_SET`, now `pub(crate)`). Verified fail-before/pass-after: without the fix the contract test fails exactly on those keys.

## Tests

- `cargo test`: full native suite green, including the 2 new contract tests.
- Full MinIO integration suite: 29 passed, 4 skipped (anonymous public-data paths exercised end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)