### PR TITLE
ci: add Claude PR review via org reusable workflow

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,21 @@
+name: Claude Auto Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+    # Skip when a PR touches workflow files: the action can't validate/run
+    # against modified workflows and fails with "401 Unauthorized - Workflow
+    # validation failed".
+    paths-ignore:
+      - '.github/workflows/**'
+
+jobs:
+  review:
+    uses: developmentseed/.github/.github/workflows/claude-pr-review.yml@main
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    # Picks up the org-level CLAUDE_CODE_OAUTH_TOKEN secret; setup and
+    # optional inputs: https://github.com/developmentseed/.github#claude-pr-review
+    secrets: inherit


### PR DESCRIPTION
Adopts the org-wide [Claude PR review reusable workflow](https://github.com/developmentseed/.github/blob/main/.github/workflows/claude-pr-review.yml) added in developmentseed/.github#6: every PR gets a Claude review for correctness/security issues plus an advisory over-engineering pass (ponytail), delivered as one sticky comment with an estimated-cost footer.

Zero configuration here — `secrets: inherit` picks up the org-level `CLAUDE_CODE_OAUTH_TOKEN` secret ([setup docs](https://github.com/developmentseed/.github#claude-pr-review)); optional inputs (`ponytail`, `plugins`, `extra_instructions`, `show_cost`) are available under `with:` if we ever want to tune it.

Notes:
- **Prerequisite:** the org secret `CLAUDE_CODE_OAUTH_TOKEN` must exist and be shared with this repo, or the review job will fail at auth.
- This PR itself won't trigger a review — the workflow skips PRs touching `.github/workflows/**` (the action can't run against modified workflow files). The first regular PR after merge is the real smoke test, and it doubles as the end-to-end validation flagged in developmentseed/.github#6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
