### PR TITLE
feat(list): skip unaddressable keys (//, ., ..) from listings

### DIFF
--- a/crates/core/src/api/list.rs
+++ b/crates/core/src/api/list.rs
@@ -291,8 +291,25 @@ fn s3_encode(s: String, url_encode: bool) -> String {
     percent_encoding::utf8_percent_encode(&s, S3_ENCODE_SET).to_string()
 }
 
-/// Filter directory markers, rewrite keys/prefixes, and URL-encode the parts of
-/// a list response that don't depend on the list-type version.
+/// Whether a key or prefix has a path segment that makes it *unaddressable*
+/// through multistore's object path: an empty segment (a `//`), or a `.`/`..`
+/// segment. `object_store::path::Path` rejects these, and multistore's
+/// `validate_key` rejects them on GET/PUT/HEAD/DELETE — so a client that saw
+/// such a key in a listing could never fetch it. We skip them from listings
+/// (logging the raw key at `warn`) to keep LIST consistent with what's actually
+/// retrievable. See issue #116.
+///
+/// Callers pass object keys as-is and common prefixes with their trailing `/`
+/// already stripped (a normal prefix like `photos/` is addressable; only an
+/// *interior* or leading empty segment is degenerate).
+fn has_degenerate_segment(s: &str) -> bool {
+    s.split('/')
+        .any(|seg| seg.is_empty() || seg == "." || seg == "..")
+}
+
+/// Filter directory markers and unaddressable keys, rewrite keys/prefixes, and
+/// URL-encode the parts of a list response that don't depend on the list-type
+/// version.
 fn collect_list_entries(
     client_prefix: &str,
     encoding_type: &Option<String>,
@@ -347,29 +364,54 @@ fn collect_list_entries(
         .objects
         .iter()
         .filter(|obj| !is_directory_marker(obj))
-        .map(|obj| ListContents {
-            // Key preserved verbatim (empty path segments intact), then rewritten
-            // and encoded per the client's request.
-            key: s3_encode(
-                rewrite_key(&obj.key, &strip_prefix, list_rewrite),
-                url_encode,
-            ),
-            last_modified: obj.last_modified.clone(),
-            etag: obj.etag.clone(),
-            size: obj.size,
-            storage_class: "STANDARD",
+        .filter_map(|obj| {
+            // Skip keys that aren't retrievable through the object path (empty
+            // `//`, `.`/`..` segments). Listing them would only advertise
+            // objects a client then can't GET. Log the raw key so operators can
+            // find and remediate it.
+            if has_degenerate_segment(&obj.key) {
+                tracing::warn!(
+                    key = %obj.key,
+                    "skipping unaddressable object key from listing (empty, `.`, or `..` path segment)"
+                );
+                return None;
+            }
+            Some(ListContents {
+                key: s3_encode(
+                    rewrite_key(&obj.key, &strip_prefix, list_rewrite),
+                    url_encode,
+                ),
+                last_modified: obj.last_modified.clone(),
+                etag: obj.etag.clone(),
+                size: obj.size,
+                storage_class: "STANDARD",
+            })
         })
         .collect();
 
     let common_prefixes: Vec<ListCommonPrefix> = list_result
         .common_prefixes
         .iter()
-        .map(|raw_prefix| ListCommonPrefix {
-            // Backend common prefixes already carry their trailing `/`.
-            prefix: s3_encode(
-                rewrite_key(raw_prefix, &strip_prefix, list_rewrite),
-                url_encode,
-            ),
+        .filter_map(|raw_prefix| {
+            // Common prefixes always end in the delimiter `/`; strip exactly
+            // that one so a genuine prefix like `photos/` reads as clean while
+            // an interior empty segment survives — `raw//` -> `raw/` still has
+            // an empty segment, whereas `trim_end_matches` would wrongly yield
+            // `raw`.
+            if has_degenerate_segment(raw_prefix.strip_suffix('/').unwrap_or(raw_prefix)) {
+                tracing::warn!(
+                    prefix = %raw_prefix,
+                    "skipping unaddressable common prefix from listing"
+                );
+                return None;
+            }
+            Some(ListCommonPrefix {
+                // Backend common prefixes already carry their trailing `/`.
+                prefix: s3_encode(
+                    rewrite_key(raw_prefix, &strip_prefix, list_rewrite),
+                    url_encode,
+                ),
+            })
         })
         .collect();
 
@@ -1106,8 +1148,10 @@ mod tests {
 
     #[test]
     fn parse_backend_list_xml_preserves_empty_path_segments() {
-        // A legal S3 key with a `//` — object_store::Path would reject this and
-        // fail the whole page. We must keep it verbatim.
+        // The parser is lenient — object_store::Path would reject a `//` key and
+        // fail the whole page, so we keep every key verbatim here. Whether an
+        // individual key is then surfaced or skipped is decided later, in
+        // `collect_list_entries`.
         let xml = br#"<?xml version="1.0" encoding="UTF-8"?>
             <ListBucketResult>
               <IsTruncated>false</IsTruncated>
@@ -1131,6 +1175,60 @@ mod tests {
         assert_eq!(result.objects[0].size, 42);
         assert_eq!(result.objects[1].key, "raw/valid.nc");
         assert!(!result.is_truncated);
+    }
+
+    #[test]
+    fn unaddressable_keys_and_prefixes_skipped_from_listing() {
+        // `//` (empty segment) and `.`/`..` keys aren't retrievable through the
+        // object path, so they're dropped from the listing while valid siblings
+        // and a normal common prefix remain.
+        let config = make_config(None);
+        let list_result = BackendListResult {
+            objects: vec![
+                BackendObject {
+                    key: "raw//b.e21.nc".into(), // empty segment
+                    last_modified: "2009-10-12T17:50:30.000Z".into(),
+                    etag: "\"a\"".into(),
+                    size: 42,
+                },
+                BackendObject {
+                    key: "raw/valid.nc".into(), // fine
+                    last_modified: "2009-10-12T17:50:30.000Z".into(),
+                    etag: "\"b\"".into(),
+                    size: 7,
+                },
+                BackendObject {
+                    key: "raw/../escape.nc".into(), // `..` segment
+                    last_modified: "2009-10-12T17:50:30.000Z".into(),
+                    etag: "\"c\"".into(),
+                    size: 9,
+                },
+            ],
+            common_prefixes: vec!["raw//".into(), "raw/good/".into()],
+            is_truncated: false,
+            next_continuation_token: None,
+        };
+
+        let params = ListXmlParams {
+            bucket_name: "b",
+            client_prefix: "raw/",
+            delimiter: "/",
+            max_keys: 1000,
+            is_truncated: false,
+            key_count: 0,
+            start_after: &None,
+            continuation_token: &None,
+            next_continuation_token: None,
+            encoding_type: &None,
+        };
+
+        let xml = build_list_xml(&params, &list_result, &config, None).unwrap();
+        assert!(xml.contains("<Key>raw/valid.nc</Key>"), "{xml}");
+        assert!(xml.contains("<Prefix>raw/good/</Prefix>"), "{xml}");
+        assert!(!xml.contains("raw//b.e21.nc"), "empty-segment key: {xml}");
+        assert!(!xml.contains("escape.nc"), "`..` key: {xml}");
+        // The degenerate common prefix `raw//` is dropped (the good one stays).
+        assert!(!xml.contains("<Prefix>raw//</Prefix>"), "{xml}");
     }
 
     #[test]

--- a/crates/core/src/proxy.rs
+++ b/crates/core/src/proxy.rs
@@ -2713,10 +2713,10 @@ mod tests {
     }
 
     /// A single stray `//` key must no longer 503 the whole prefix: the page
-    /// returns 200 with the offending key preserved verbatim alongside its
-    /// siblings.
+    /// returns 200 with valid siblings listed and the unaddressable `//` key
+    /// skipped (it isn't retrievable through the object path anyway).
     #[test]
-    fn list_preserves_empty_path_segment_key() {
+    fn list_skips_empty_path_segment_key() {
         run(async {
             let captured_url = Arc::new(std::sync::Mutex::new(None));
             let backend = ListMockBackend {
@@ -2751,11 +2751,12 @@ mod tests {
                 ProxyResponseBody::Bytes(b) => String::from_utf8(b.to_vec()).unwrap(),
                 ProxyResponseBody::Empty => panic!("expected a body"),
             };
-            assert!(
-                xml.contains("<Key>raw//b.e21.nc</Key>"),
-                "empty-segment key must survive: {xml}"
-            );
+            // The valid sibling is listed; the `//` key is skipped, not 503'd.
             assert!(xml.contains("<Key>raw/valid.nc</Key>"), "{xml}");
+            assert!(
+                !xml.contains("raw//b.e21.nc"),
+                "unaddressable // key must be skipped: {xml}"
+            );
 
             // The backend request carried list-type=2 and the mapped prefix.
             let url = captured_url.lock().unwrap().clone().unwrap();


### PR DESCRIPTION
## What I'm changing

**Stacks on #117** (base branch is `worktree-fix-116-empty-path-segment`, not `main`).

#117 stopped a single `//`-segment key from 503-ing an entire prefix, but as a side effect it *surfaced* those keys in the listing even though they can't be fetched: `object_store::path::Path` rejects a `//`/`.`/`..` key and `validate_key` returns 400 on any GET/HEAD/PUT/DELETE of one. That left a `//` object **visible-but-unretrievable** — a client sees it in the listing and then gets a 400 trying to fetch it.

This PR resolves that inconsistency the simple way: **skip unaddressable keys from listings** so LIST only advertises objects that are actually retrievable, logging the raw key at `warn` so operators can find and remediate the stray upload (as the issue suggested).

A diagnostic against the real bucket (`obstore`, the Python binding of the same Rust `object_store` crate) confirmed these keys fail client-side at path-parse for HEAD, GET, *and* LIST — they are unreachable through object_store by any route:

```
[ FAIL ] HEAD the // key: ValueError: ... Path "raw//..." contained empty path segment
[ FAIL ] GET the // key:  ValueError: ... contained empty path segment
```

> **Note:** this is the intentionally-lazy treatment. It makes `//` objects *invisible* through the gateway rather than *retrievable*. The alternative — a custom byte-faithful presigner that makes `//` keys individually fetchable — was considered and deferred; it's more work (new SigV4 signing code) and only warranted if such objects are real data that must be reachable. For now they're treated as unaddressable.

## How I did it

- **`api/list.rs`** — `has_degenerate_segment` (empty / `.` / `..` path segment) filters `collect_list_entries` for both objects and common prefixes. Common prefixes strip exactly one trailing delimiter first, so `raw//` is caught while a genuine `photos/` is not (`trim_end_matches` would wrongly clean `raw//` to `raw`).
- **Tests** — `unaddressable_keys_and_prefixes_skipped_from_listing` (unit) covers `//`, `..`, and a degenerate common prefix; the proxy end-to-end test now asserts the `//` key is skipped rather than surfaced.

## Test plan

- [x] `cargo test -p multistore --lib` — 131 pass
- [x] `cargo clippy -p multistore --all-targets` — clean (no new warnings)
- [x] `cargo check -p multistore-cf-workers --target wasm32-unknown-unknown` — compiles
- [x] `obstore` diagnostic against the real `ncar-cesm2-arise` bucket confirms the `//` key is unreachable via object_store

🤖 Generated with [Claude Code](https://claude.com/claude-code)