### PR TITLE
ci: retry smoke tests to absorb Cloudflare edge propagation flakes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -144,4 +144,11 @@ jobs:
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Run smoke tests
-        run: uvx --with pytest,boto3,requests pytest tests/smoke/ -v
+        # A freshly deployed script propagates per edge machine, not per
+        # hostname: for a few seconds after deploy some requests to the same
+        # workers.dev host are answered by a machine that doesn't have it yet
+        # and get Cloudflare's HTML "Page not found" 404, while neighbouring
+        # requests in the same second succeed. No probe loop in the deploy job
+        # can gate on that (it may keep hitting warm machines), so retry here.
+        # A real regression still fails every rerun.
+        run: uvx --with pytest,boto3,requests,pytest-rerunfailures pytest tests/smoke/ -v --reruns 4 --reruns-delay 5


### PR DESCRIPTION
## What I'm changing

The smoke-test job fails intermittently on PR previews (e.g. [run 30306016560](https://github.com/developmentseed/multistore/actions/runs/30306016560) attempt 1, which passed unchanged on attempt 2). The failures are not ours: the 404 bodies are Cloudflare's `<title>Page not found</title>` workers.dev placeholder, and they interleave with passing requests to the same host in the same second.

A freshly deployed Worker propagates per edge machine, not per hostname. For a few seconds after `wrangler deploy`, some requests to `multistore-proxy-pr-N.<subdomain>.workers.dev` land on a machine that does not have the script yet and get the placeholder 404; neighbouring requests succeed. In that run `test_assume_role_returns_credentials` passed at 21:16:13.3 while the fixture behind `test_assume_no_access_role_returns_credentials` 404'd at 21:16:13.4.

The existing `Wait for deployment to be live` gate (3 consecutive successful probes) cannot close this: it probes one URL and its probes may all be answered by machines that are already warm, so it reports live while others still 404.

## How I did it

- `.github/workflows/deploy.yml` — `Run smoke tests` now installs `pytest-rerunfailures` and runs with `--reruns 4 --reruns-delay 5`, giving ~20s of retry coverage for the propagation window. Comment above the step records why the deploy-side probe loop cannot solve this instead.

Retries are scoped to the smoke job only; `tests/integration/` in `ci.yml` is unchanged. A genuine regression fails all five attempts, so this hides nothing — it costs ~20s on a real failure.

## Test plan

- [x] `deploy.yml` parses (`yaml.safe_load`)
- [x] Confirmed `pytest-rerunfailures` retries **fixture setup errors**, not just test-body failures — the smoke suite's 404s surface as setup errors on the `assume_no_access` fixture, so this was the load-bearing assumption. Verified with a throwaway suite whose fixture raises on its first two invocations: `1 passed, 2 rerun`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)