### PR TITLE
fix(cf-workers): log the request-body pipe's rejection instead of dropping it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1314,7 +1314,7 @@ dependencies = [
 
 [[package]]
 name = "multistore"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-cf-workers"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-cf-workers-example"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "bytes",
  "console_error_panic_hook",
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-lambda"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "bytes",
  "http",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-metering"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "bytes",
  "futures",
@@ -1423,7 +1423,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-oidc-provider"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "base64",
  "chrono",
@@ -1442,7 +1442,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-path-mapping"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "multistore",
  "percent-encoding",
@@ -1451,7 +1451,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-server"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "axum",
  "bytes",
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-static-config"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "chrono",
  "multistore",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-sts"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/crates/cf-workers/src/backend.rs
+++ b/crates/cf-workers/src/backend.rs
@@ -60,6 +60,32 @@ fn new_fixed_length_stream(
     }
 }
 
+/// Observe the request-body pipe so its failure reason reaches the logs instead
+/// of being discarded.
+///
+/// Spawns rather than awaits: `forward` must return as soon as the outbound
+/// response headers arrive, and the pipe is still driven by that fetch's
+/// backpressure. The spawned task only observes a promise — it performs no I/O
+/// of its own and does not extend the request's lifetime.
+///
+/// The rejection is the only place the real cause is visible — the inbound body
+/// ending short of, or running past, the declared `Content-Length` (either errors
+/// the `FixedLengthStream`), the inbound stream itself erroring, or the outbound
+/// fetch cancelling `readable`. Downstream all of these look identical: a
+/// truncated subrequest body and an origin that hangs up without responding.
+fn log_pipe_rejection(pipe: js_sys::Promise, declared_len: u64) {
+    wasm_bindgen_futures::spawn_local(async move {
+        if let Err(err) = wasm_bindgen_futures::JsFuture::from(pipe).await {
+            tracing::warn!(
+                declared_content_length = declared_len,
+                error = ?err,
+                "request body pipe failed; the outbound body is truncated and the \
+                 origin will likely close without responding"
+            );
+        }
+    });
+}
+
 impl ProxyBackend for WorkerBackend {
     type ResponseBody = web_sys::Response;
     type Body = JsBody;
@@ -104,13 +130,18 @@ impl ProxyBackend for WorkerBackend {
                         let transform: &web_sys::TransformStream = fls.as_ref();
                         // The outbound fetch consuming `readable` pulls the body
                         // through the transform; the pipe is driven by that
-                        // backpressure, so it streams rather than buffers. The
-                        // returned promise is intentionally dropped: a pipe
-                        // failure (e.g. the client sending fewer/more bytes than
-                        // Content-Length, which errors the FixedLengthStream)
-                        // also errors `readable`, so the awaited outbound fetch
-                        // fails and the error surfaces there.
-                        let _ = stream.pipe_to(&transform.writable());
+                        // backpressure, so it streams rather than buffers.
+                        //
+                        // The pipe's rejection is logged rather than discarded.
+                        // It used to be dropped on the reasoning that a pipe
+                        // failure also errors `readable`, so the awaited outbound
+                        // fetch would surface it. In practice it does not: the
+                        // origin sees a truncated request, closes without
+                        // replying, and the runtime turns that into a
+                        // Cloudflare-minted `error code: 520` carrying no
+                        // diagnostic — no origin request id, no error document.
+                        // The reason the body pipe failed is then unrecoverable.
+                        log_pipe_rejection(stream.pipe_to(&transform.writable()), len);
                         init.set_body(&transform.readable());
                     }
                     None => init.set_body(stream),


### PR DESCRIPTION
## What I'm changing

`WorkerBackend::forward` pipes a streamed PUT body into a `FixedLengthStream` and discards the `pipe_to` promise. The comment justified it: a pipe failure also errors `readable`, so the awaited outbound fetch would surface the error.

It does not. Chasing a persistent ~0.1% failure rate on `PutObject`/`UploadPart` in a downstream proxy, the observed sequence is:

1. the pipe fails early — within ~80–140 ms, a few hundred KB into a multi-MB body;
2. the origin receives a truncated request and closes **without sending any HTTP response**;
3. the runtime turns that into a Cloudflare-minted `error code: 520` — `server: cloudflare`, a subrequest `cf-ray`, `text/plain`, 16 bytes, **no** origin request id and no error document;
4. `GatewayResponse::Forward` relays that status faithfully, so the caller gets a 520 whose body no AWS SDK can deserialize.

Every trace of *why* the pipe failed is gone, because the only object that carried it was dropped on the floor. That is the gap this closes. It does not fix the failure — it makes the failure legible.

Confirmed from production logs across two independent invocations (4.9 MB `PutObject` and 16 MiB `UploadPart`), both showing the identical Cloudflare-origin signature with zero `x-amz-*` headers.

## How I did it

- **`crates/cf-workers/src/backend.rs`** — new `log_pipe_rejection(pipe, declared_len)`. Observes the `pipe_to` promise on `wasm_bindgen_futures::spawn_local` and logs the rejection at WARN with the declared `Content-Length`. Spawned rather than awaited: `forward` must still return as soon as the outbound response headers arrive, and the pipe is driven by that fetch's backpressure. The task only observes a promise — it issues no I/O and does not extend the request's lifetime.
- Replaced `let _ = stream.pipe_to(...)` with the call, and rewrote the comment: the old one asserted behaviour that production contradicts, which is worse than no comment.
- The doc comment names the causes that are indistinguishable downstream but distinct here: inbound body short of or past the declared `Content-Length` (either errors the `FixedLengthStream`), the inbound stream erroring, or the outbound fetch cancelling `readable`.
- **`Cargo.lock`** — was stale on `main` at the workspace's previous version; the pre-commit clippy hook regenerates it on every run, so it is included rather than fought.

Diagnostic only. No behaviour change, and the `None` (aws-chunked) branch is untouched — it has no pipe to observe.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --fix -p multistore-cf-workers --target wasm32-unknown-unknown`
- [x] `cargo check`
- [x] `cargo check -p multistore-cf-workers --target wasm32-unknown-unknown`
- [x] pre-commit hooks (fmt, clippy --fix, check, check-wasm) all pass

No test accompanies this. The crate has no wasm test harness — the only `cfg(test)` module is a host-side one in `cors.rs` — and the behaviour needs a live `ReadableStream` under a real Workers runtime to exercise. Flagging that rather than papering over it: the repo convention is a failing test first, and I could not write one that would actually fail.

## Follow-up

Once the rejection reason is visible, the real fix follows. If the pipe is failing on a length mismatch, the outbound request should fail with a proper `ProxyError` rather than letting a truncated body reach the origin and turn into an opaque 520.