### PR TITLE
fix(cf-workers): size aws-chunked streamed PUTs so the egress leg has a Content-Length

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1314,7 +1314,7 @@ dependencies = [
 
 [[package]]
 name = "multistore"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-cf-workers"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-cf-workers-example"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "bytes",
  "console_error_panic_hook",
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-lambda"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "bytes",
  "http",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-metering"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "bytes",
  "futures",
@@ -1423,7 +1423,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-oidc-provider"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "base64",
  "chrono",
@@ -1442,7 +1442,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-path-mapping"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "multistore",
  "percent-encoding",
@@ -1451,7 +1451,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-server"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "axum",
  "bytes",
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-static-config"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "chrono",
  "multistore",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-sts"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "aes-gcm",
  "base64",

--- a/crates/cf-workers/src/backend.rs
+++ b/crates/cf-workers/src/backend.rs
@@ -11,7 +11,9 @@ use crate::response::headermap_from_js;
 use bytes::Bytes;
 use http::HeaderMap;
 use multistore::backend::ForwardResponse;
-use multistore::backend::{build_signer, create_builder, ProxyBackend, RawResponse, StoreBuilder};
+use multistore::backend::{
+    build_signer, create_builder, streamed_put_body_length, ProxyBackend, RawResponse, StoreBuilder,
+};
 use multistore::error::ProxyError;
 use multistore::route_handler::ForwardRequest;
 use multistore::types::BucketConfig;
@@ -28,25 +30,6 @@ use worker::Fetch;
 /// for raw multipart operations.
 #[derive(Clone)]
 pub struct WorkerBackend;
-
-/// The byte length to wrap a streamed PUT body in, or `None` to forward the raw
-/// stream. Returns `None` for aws-chunked bodies (S3 sizes those from
-/// `x-amz-decoded-content-length`) and for bodies with no usable
-/// `Content-Length`.
-fn fixed_body_length(headers: &HeaderMap) -> Option<u64> {
-    let aws_chunked = headers
-        .get(http::header::CONTENT_ENCODING)
-        .and_then(|v| v.to_str().ok())
-        .map(|v| v.contains("aws-chunked"))
-        .unwrap_or(false);
-    if aws_chunked {
-        return None;
-    }
-    headers
-        .get(http::header::CONTENT_LENGTH)
-        .and_then(|v| v.to_str().ok())
-        .and_then(|v| v.parse::<u64>().ok())
-}
 
 /// Build a Cloudflare `FixedLengthStream` of the given length (parts can exceed
 /// `u32::MAX`, so fall back to the BigInt constructor).
@@ -86,17 +69,24 @@ impl ProxyBackend for WorkerBackend {
 
         // For PUT: stream the body through without buffering it in WASM memory.
         // A bare `ReadableStream` body makes the Workers runtime send the
-        // subrequest with
-        // `Transfer-Encoding: chunked` and *drop* `Content-Length` — which S3
-        // rejects for a non-aws-chunked payload (it can't size the object/part),
-        // leaving the subrequest hung until the whole body streams through.
-        // Wrapping the stream in a `FixedLengthStream` makes the runtime emit a
-        // real `Content-Length`. aws-chunked bodies are sized by S3 from
-        // `x-amz-decoded-content-length` and keep their chunk framing, so those
-        // pass through raw.
+        // subrequest with `Transfer-Encoding: chunked` and *drop*
+        // `Content-Length`, leaving S3 unable to size the object/part. Wrapping
+        // the stream in a `FixedLengthStream` makes the runtime emit a real
+        // `Content-Length` instead.
+        //
+        // This applies to aws-chunked bodies too. They were previously exempted
+        // on the grounds that S3 sizes them from `x-amz-decoded-content-length`,
+        // but that only sizes the *de-chunked payload* — the HTTP leg itself was
+        // still left unsized, and an unsized leg is what an origin hangs up on
+        // without answering (surfacing as a Cloudflare-minted 520 on the
+        // worker's egress). `Content-Length` is the encoded byte count, framing
+        // and trailer included, so it sizes the leg without reframing the body:
+        // the chunk framing still reaches S3 untouched. It is forwarded
+        // *unsigned* (see `build_streaming_forward`), so changing the transfer
+        // framing cannot invalidate the SigV4 signature.
         if request.method == http::Method::PUT {
             if let Some(stream) = js_body.stream() {
-                match fixed_body_length(&request.headers) {
+                match streamed_put_body_length(&request.headers) {
                     Some(len) => {
                         let fls = new_fixed_length_stream(len).map_err(|e| {
                             ProxyError::Internal(format!("FixedLengthStream init failed: {e:?}"))

--- a/crates/core/src/backend/mod.rs
+++ b/crates/core/src/backend/mod.rs
@@ -209,3 +209,73 @@ pub fn create_builder(config: &BucketConfig) -> Result<StoreBuilder, ProxyError>
         )),
     }
 }
+
+/// The byte length to wrap a streamed PUT body in, or `None` to forward the raw
+/// stream unsized.
+///
+/// Runtimes that stream a PUT body through without buffering need this: a bare
+/// stream body makes the Cloudflare Workers runtime send the subrequest with
+/// `Transfer-Encoding: chunked` and *drop* `Content-Length`, and an S3 origin
+/// that never learns the body size can hang up without answering at all.
+///
+/// `Content-Length` is the correct size for both body shapes, `aws-chunked`
+/// included: it counts the bytes actually placed on the wire — chunk framing and
+/// trailer included — whereas `x-amz-decoded-content-length` counts only the
+/// payload S3 reconstructs after de-chunking. Sizing the leg does not reframe
+/// the body, so the chunk framing reaches S3 untouched.
+///
+/// Returns `None` only when there is no usable `Content-Length` to size with.
+pub fn streamed_put_body_length(headers: &HeaderMap) -> Option<u64> {
+    headers
+        .get(http::header::CONTENT_LENGTH)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.parse::<u64>().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn headers(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        for (k, v) in pairs {
+            h.insert(
+                http::HeaderName::from_bytes(k.as_bytes()).unwrap(),
+                v.parse().unwrap(),
+            );
+        }
+        h
+    }
+
+    #[test]
+    fn plain_put_is_sized_by_content_length() {
+        assert_eq!(
+            streamed_put_body_length(&headers(&[("content-length", "1024")])),
+            Some(1024)
+        );
+    }
+
+    /// An `aws-chunked` body must be sized too. Its `Content-Length` is the
+    /// *encoded* length — the 135-byte gap here is the chunk framing plus the
+    /// CRC32 trailer — which is exactly what goes on the wire.
+    #[test]
+    fn aws_chunked_put_is_sized_by_encoded_content_length() {
+        let h = headers(&[
+            ("content-encoding", "aws-chunked"),
+            ("content-length", "10094598"),
+            ("x-amz-decoded-content-length", "10094463"),
+            ("x-amz-trailer", "x-amz-checksum-crc32"),
+        ]);
+        assert_eq!(streamed_put_body_length(&h), Some(10094598));
+    }
+
+    #[test]
+    fn no_content_length_forwards_raw_stream() {
+        assert_eq!(streamed_put_body_length(&headers(&[])), None);
+        let chunked_only = headers(&[
+            ("content-encoding", "aws-chunked"),
+            ("x-amz-decoded-content-length", "10094463"),
+        ]);
+        assert_eq!(streamed_put_body_length(&chunked_only), None);
+    }
+}


### PR DESCRIPTION
Candidate fix for intermittent 520s on streamed uploads through the Workers runtime. See [source-cooperative/data.source.coop#206](https://github.com/source-cooperative/data.source.coop/issues/206) for the production evidence.

## What I'm changing

`WorkerBackend::forward` streams PUT bodies through without buffering them into WASM memory. A bare `ReadableStream` body makes the Workers runtime send the subrequest with `Transfer-Encoding: chunked` and **drop `Content-Length`**, so the branch wraps the stream in a `FixedLengthStream` to force a real `Content-Length` — except that `fixed_body_length()` returned `None` for any `content-encoding: aws-chunked` body, exempting exactly the shape AWS SDKs and the CLI send by default.

The exemption was justified in-comment by "aws-chunked bodies are sized by S3 from `x-amz-decoded-content-length`". That is true for the *object*: S3 uses it to size the payload it reconstructs after de-chunking. It says nothing about the *HTTP leg*, which was left unsized.

`Content-Length` is the correct size for an aws-chunked body too. It counts the bytes actually placed on the wire — chunk framing and trailer included — e.g. `10094598` encoded vs `10094463` decoded, a 135-byte gap of framing plus the CRC32 trailer. Sizing the leg does not reframe the body, so the chunk framing still reaches S3 untouched. It is forwarded **unsigned** (`build_streaming_forward`: "the transfer framing is the runtime's to manage, so signing it risks a mismatch"), so changing the framing cannot invalidate the SigV4 signature.

## Why this is a candidate and not a confirmed fix

On `data.source.coop`, ~0.6% of aws-chunked PUTs (25/4,059 in a 15-minute production sample) fail as a **Cloudflare-minted 520 on the worker's own egress leg** — `server: cloudflare`, no `x-amz-*` headers, a 16-byte `error code: 520` body, dead in 34–701 ms. S3 never produces an HTTP response at all.

That rate is the problem for this change's own theory. The failures are **Poisson** (CV of inter-failure gaps = 0.99) and **independent of body size** (failed p50 6.56 MB vs succeeded 6.76 MB) and of colo (0.43% vs 0.82% across the only two in the sample). A structurally identical request failing 0.6% of the time is a **race**, not a protocol defect — if an unsized chunked leg were simply rejected, the rate would be ~100%, not 0.6%. S3 evidently accepts this wire shape thousands of times per window.

**So the missing `Content-Length` can be at most a predisposing condition, never the trigger.** The surviving form of the argument is second-order: a request with a known `Content-Length` is replayable, whereas a chunked body streaming from a live inbound socket is not — so a transient egress event (a stale pooled keep-alive connection, a reset) that would otherwise be retried invisibly instead surfaces as an empty response. Pooled-connection races are Poisson, size-independent, and kill you just after headers, which fits. That is a plausible mechanism, not a demonstrated one, and the 520 is minted inside Cloudflare's egress so S3's side of the connection is not observable from the worker.

**This PR may therefore be a no-op for the bug.** #141 (stacked on this branch) is the experiment that tells you: it captures the `pipe_to` rejection, and a 520 arriving with no rejection is connection-side evidence for this change, while one arriving with a rejection means the fault is body-side and this change is irrelevant. Landing this without that instrumentation risks a green soak that nobody can attribute.

Independent of whether it fixes the 520s, the sizing itself is a correctness improvement: an unsized leg is a strictly worse thing to hand an origin than a sized one, at no cost.

## How I did it

- **`crates/core/src/backend/mod.rs`** — new `pub fn streamed_put_body_length(&HeaderMap) -> Option<u64>`: the old helper minus the aws-chunked early return, so `Content-Length` now sizes both body shapes. Returns `None` only when there is no usable `Content-Length`. Doc comment records why the encoded length is the right number and why this does not disturb the framing.
- **`crates/cf-workers/src/backend.rs`** — drops the local `fixed_body_length`, calls the core helper, and rewrites the stale rationale comment on the PUT branch.
- **Why the move.** `crates/cf-workers` is absent from the workspace `default-members`, so `cargo test` never compiles it and a `#[cfg(test)]` module there would be dead (the existing one in `cors.rs` never runs). The function is pure header inspection with no `wasm` dependencies, so hosting it in `crates/core` — next to the existing free `pub fn create_builder` — is what makes it testable at all. No visibility widening was needed elsewhere.
- No `docs/` change: the sizing behaviour is not documented there (`docs/reference/operations.md` covers aws-chunked only for conditional-write precondition forwarding).
- `Cargo.lock` deliberately left untouched; it carries an unrelated stale `0.7.1`→`0.7.2` version correction.

## Test plan

Bug-first, per `CLAUDE.md`. The three tests were added against the **unfixed** helper and `aws_chunked_put_is_sized_by_encoded_content_length` failed as intended (`left: None, right: Some(10094598)`) before the early return was removed — so the test demonstrably detects the bug rather than merely passing.

- [x] `cargo test` — 161 core + all suites pass, 0 failures
- [x] `cargo fmt`
- [x] `cargo clippy --all-targets` — clean (one pre-existing `too_many_arguments` warning, unrelated)
- [x] `cargo check -p multistore-cf-workers --target wasm32-unknown-unknown`

Not covered here, and needed before this can be called confirmed:

- [ ] **Attribute the failure with #141 first** — a 520 with no pipe rejection is connection-side (supports this PR); a 520 with one is body-side (this PR is irrelevant to the bug).
- [ ] **Framing assertion against a stub origin** — that an aws-chunked PUT's subrequest now carries `Content-Length` and no `Transfer-Encoding: chunked`, and that the bytes arrive byte-identical with framing and CRC32 trailer intact. This needs a workerd/miniflare harness, which does not exist in this repo.
- [ ] **Soak.** At a 0.6% baseline a small clean run proves nothing — `(1-0.006)^100` ≈ 55%. Roughly **1,000** consecutive clean multi-MB aws-chunked PUTs puts the odds of a broken fix still looking clean near 0.2%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B3x2KzUtojpwPvDKmSgvht
