### PR TITLE
feat(cf-workers): log the streamed PUT body pipe's rejection

### DIFF
--- a/crates/cf-workers/src/backend.rs
+++ b/crates/cf-workers/src/backend.rs
@@ -94,13 +94,30 @@ impl ProxyBackend for WorkerBackend {
                         let transform: &web_sys::TransformStream = fls.as_ref();
                         // The outbound fetch consuming `readable` pulls the body
                         // through the transform; the pipe is driven by that
-                        // backpressure, so it streams rather than buffers. The
-                        // returned promise is intentionally dropped: a pipe
-                        // failure (e.g. the client sending fewer/more bytes than
-                        // Content-Length, which errors the FixedLengthStream)
-                        // also errors `readable`, so the awaited outbound fetch
-                        // fails and the error surfaces there.
-                        let _ = stream.pipe_to(&transform.writable());
+                        // backpressure, so it streams rather than buffers.
+                        //
+                        // The pipe is still not awaited inline — doing so would
+                        // deadlock, since nothing drains `readable` until the
+                        // fetch below runs — but its rejection is no longer
+                        // dropped. A pipe failure also errors `readable`, so the
+                        // outbound fetch fails on its own either way; what the
+                        // fetch cannot report is *why* the body stopped. That
+                        // distinction is the whole diagnostic: a body-side
+                        // failure rejects here, whereas a connection-side one
+                        // leaves the pipe healthy and fails only at the fetch.
+                        // Observability only — backpressure and streaming are
+                        // unchanged.
+                        let pipe = stream.pipe_to(&transform.writable());
+                        let pipe_request_id = request.request_id.clone();
+                        wasm_bindgen_futures::spawn_local(async move {
+                            if let Err(e) = wasm_bindgen_futures::JsFuture::from(pipe).await {
+                                tracing::warn!(
+                                    request_id = %pipe_request_id,
+                                    error = ?e,
+                                    "streamed PUT body pipe failed"
+                                );
+                            }
+                        });
                         init.set_body(&transform.readable());
                     }
                     None => init.set_body(stream),


### PR DESCRIPTION
> **Stacked on #140** — base that branch, not `main`. See below for why it cannot usefully stand alone.

Diagnostic for [source-cooperative/data.source.coop#206](https://github.com/source-cooperative/data.source.coop/issues/206). This changes no behaviour; it exists to discriminate between two competing explanations that current logging cannot separate.

## What I'm changing

`WorkerBackend::forward` dropped the promise returned by `stream.pipe_to(&transform.writable())`. The existing reasoning is sound as far as it goes — a pipe failure also errors `readable`, so the awaited outbound fetch fails regardless. But the fetch only reports *that* it failed, never **why the body stopped**, and that is exactly the missing bit.

Production evidence on `data.source.coop`: ~0.6% of streamed PUTs die as a Cloudflare-minted 520 on the worker's egress leg, with S3 never answering. The rate is **Poisson** (CV of inter-failure gaps = 0.99) and **independent of body size** (failed p50 6.56 MB vs succeeded 6.76 MB), which makes it a per-request race rather than a protocol defect — a structural defect would fail ~100% of the time, not 0.6%.

The two candidate races sit on opposite sides of this promise:

| observation | conclusion |
|---|---|
| pipe **rejects** on a failing request | body-side failure — the inbound stream broke, and #140 is irrelevant to this bug |
| pipe stays healthy, fetch still returns **520** | connection-side failure — supports #140's replayability argument |

Right now we cannot tell which, so we cannot tell whether #140 is a fix or a no-op.

## Why this is stacked on #140 rather than independent

On `main` the pipe exists **only** in the `Some(len)` (`FixedLengthStream`) branch. `fixed_body_length()` returns `None` for `aws-chunked`, so those requests take `init.set_body(stream)` and never touch the pipe at all — and every failure in the 4,059-PUT production sample was `aws-chunked`.

So on `main` this handler instruments a path the dominant failure mode never takes, and would log nothing. #140 is what routes `aws-chunked` through the transform, which is what makes this promise observable for the requests that actually fail. Landing this on its own would produce silence and be misread as evidence.

A useful corollary: it also means the dropped pipe cannot be the cause of the `aws-chunked` 520s as they occur on `main` today — there is no pipe on that path. The pipe-race theory only ever applied to the plain-`Content-Length` shape.

## How I did it

- **`crates/cf-workers/src/backend.rs`** — bind the pipe promise, clone `request.request_id` for correlation, and `spawn_local` a task that logs a `warn` with the `JsValue` error if it rejects. The pipe is deliberately still **not awaited inline**: nothing drains `readable` until the fetch below runs, so awaiting it there would deadlock. Only the rejection is captured, so backpressure and streaming are unchanged.
- Replaces the comment justifying the dropped promise with one explaining what the captured rejection distinguishes.

Side effect worth expecting: the unattributed `TypeError: Can't read from request stream after responding with an exception` already visible in Workers logs should now arrive as an attributed `streamed PUT body pipe failed` line carrying a `request_id`, instead of a bare unhandled rejection.

## Test plan

- [x] `cargo check -p multistore-cf-workers --target wasm32-unknown-unknown`
- [x] `cargo fmt`, `cargo clippy --all-targets`, `cargo check`
- [ ] No unit test: the behaviour is a runtime promise rejection in the Workers runtime, which the host-target test suite cannot exercise (`crates/cf-workers` is not in the workspace `default-members`). Verification is reading production logs after deploy.

**How to read the result once deployed:** filter Workers logs for `streamed PUT body pipe failed` and join to the existing `server error response` line on `request_id`. A 520 with a matching pipe rejection is body-side; a 520 with none is connection-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B3x2KzUtojpwPvDKmSgvht