### PR TITLE
chore(deps): resolve cargo audit advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,9 +57,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "async-stream"
@@ -270,9 +270,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -489,7 +489,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -678,9 +678,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1314,7 +1314,7 @@ dependencies = [
 
 [[package]]
 name = "multistore"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "base64",
@@ -1341,7 +1341,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-cf-workers"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1366,7 +1366,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-cf-workers-example"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "bytes",
  "console_error_panic_hook",
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-lambda"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "bytes",
  "http",
@@ -1411,7 +1411,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-metering"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "bytes",
  "futures",
@@ -1423,13 +1423,13 @@ dependencies = [
 
 [[package]]
 name = "multistore-oidc-provider"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "base64",
  "chrono",
  "multistore",
  "quick-xml 0.41.0",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "serde_json",
@@ -1442,7 +1442,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-path-mapping"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "multistore",
  "percent-encoding",
@@ -1451,7 +1451,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-server"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "axum",
  "bytes",
@@ -1473,7 +1473,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-static-config"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "chrono",
  "multistore",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "multistore-sts"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -1493,7 +1493,7 @@ dependencies = [
  "http",
  "multistore",
  "quick-xml 0.41.0",
- "rand 0.8.5",
+ "rand 0.8.6",
  "reqwest",
  "rsa",
  "serde",
@@ -1524,7 +1524,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -1824,7 +1824,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1847,7 +1847,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1873,9 +1873,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -1884,9 +1884,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2118,7 +2118,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2992,7 +2992,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]


### PR DESCRIPTION
## What I'm changing

`cargo audit` on `main` reported one actual vulnerability and several soundness/yank warnings:

- **RUSTSEC-2026-0258** — `h2` 0.4.13 is vulnerable to unbounded empty DATA frames (a resource-exhaustion DoS vector). This was the one advisory failing the CI `Audit` job.
- **RUSTSEC-2026-0190** — `anyhow` 1.0.102's `Error::downcast_mut()` is unsound (constructs an aliased mutable reference, UB under Stacked Borrows).
- **RUSTSEC-2026-0097** — `rand` 0.8.5/0.9.2 are unsound when a custom `log` logger calls into `rand::rng()`/`rand::thread_rng()` during reseeding.
- `chacha20` 0.10.1 was yanked from crates.io; 0.10.2 is the current release.

None of these are direct dependencies — all are pulled in transitively (`h2`/`rand`/`chacha20` via `reqwest`/`object_store`, `anyhow` via various crates), so no `Cargo.toml` changes were needed, only `Cargo.lock` updates within existing semver ranges.

## How I did it

- `cargo update -p h2 --precise 0.4.16` — clears RUSTSEC-2026-0258.
- `cargo update -p anyhow --precise 1.0.103` — clears RUSTSEC-2026-0190.
- `cargo update -p rand@0.8.5 --precise 0.8.6` and `cargo update -p rand@0.9.2 --precise 0.9.3` — clears RUSTSEC-2026-0097 for both rand lines in the tree.
- `cargo update -p chacha20 --precise 0.10.2` — clears the yanked-crate warning.
- `Cargo.lock` also picked up a handful of `multistore-*` workspace-member entries moving from `0.7.1` to `0.7.2`, matching the version already set in `Cargo.toml`/`workspace.package` — the lockfile was stale relative to that prior release bump and got resynced as a side effect of `cargo update`.
- `errno`, `quinn-udp`, `rustls-platform-verifier`, and `winapi-util` moved from `windows-sys` 0.60.2/0.61.2 down to 0.52.0. This isn't a regression: `ring` hard-pins `windows-sys = "^0.52"`, and cargo's resolver unifies onto that shared entry once the lockfile is freshly re-resolved (confirmed — asking cargo to move the shared entry back up fails with `ring`'s pin as the blocker). `windows-sys` only affects Windows builds (this project targets Linux/wasm32) and 0.52.0 carries no known advisory, so this is left as-is rather than fought.

## Not fixed

- **`spin` 0.9.8 — yanked.** Pulled in transitively via `lazy_static` (required by `rsa` → `multistore-oidc-provider`/`multistore-sts`), which pins `spin = "^0.9.8"`. The only newer release (`0.10.1`) is semver-incompatible with that requirement, so it can't be bumped without an upstream fix in `lazy_static` (or dropping it from the dependency tree). This is a yank warning, not a CVE.

## Test plan

- [x] `cargo audit` — no vulnerabilities; only the `spin` yank warning remains (unfixable, see above)
- [x] `cargo check`
- [x] `cargo check -p multistore-cf-workers --target wasm32-unknown-unknown`
- [x] `cargo test` (default workspace members)
- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`